### PR TITLE
Enforce the correct OpenPGP pubkey for verification

### DIFF
--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -39,7 +39,7 @@ ADDRESS=$(hostname -I | cut -d ' ' -f 1)
 GITHUB_REPO="https://raw.githubusercontent.com/nextcloud/vm/master"
 STATIC="https://raw.githubusercontent.com/nextcloud/vm/master/static"
 NCREPO="https://download.nextcloud.com/server/releases/"
-GPGKEY="https://nextcloud.com/nextcloud.asc"
+OpenPGP_fingerprint='28806A878AE423A28372792ED75899B9A724937A'
 # Commands
 CLEARBOOT=$(dpkg -l linux-* | awk '/^ii/{ print $2}' | grep -v -e `uname -r | cut -f1,2 -d"-"` | grep -e [0-9] | xargs sudo apt-get -y purge)
 # Linux user, and Nextcloud user
@@ -273,10 +273,9 @@ apt-get install unzip -y
 wget -q $NCREPO/$STABLEVERSION.zip -P $HTML
 mkdir -p $GPGDIR
 wget -q $NCREPO/$STABLEVERSION.zip.asc -P $GPGDIR
-wget -q $GPGKEY -P $GPGDIR
 chmod -R 600 $GPGDIR
-gpg  --homedir $GPGDIR --import $GPGDIR/nextcloud.asc
-gpg  --homedir $GPGDIR --verify $GPGDIR/$STABLEVERSION.zip.asc $HTML/$STABLEVERSION.zip
+gpg --homedir $GPGDIR --keyserver ha.pool.sks-keyservers.net --recv-keys "$OpenPGP_fingerprint"
+gpg --homedir $GPGDIR --verify $GPGDIR/$STABLEVERSION.zip.asc $HTML/$STABLEVERSION.zip
 if [[ $? > 0 ]]
 then
         echo "Package NOT OK! Installation is aborted..."

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -274,8 +274,8 @@ wget -q $NCREPO/$STABLEVERSION.zip -P $HTML
 mkdir -p $GPGDIR
 wget -q $NCREPO/$STABLEVERSION.zip.asc -P $GPGDIR
 chmod -R 600 $GPGDIR
-gpg --homedir $GPGDIR --keyserver ha.pool.sks-keyservers.net --recv-keys "$OpenPGP_fingerprint"
-gpg --homedir $GPGDIR --verify $GPGDIR/$STABLEVERSION.zip.asc $HTML/$STABLEVERSION.zip
+gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$OpenPGP_fingerprint"
+gpg --verify $GPGDIR/$STABLEVERSION.zip.asc $HTML/$STABLEVERSION.zip
 if [[ $? > 0 ]]
 then
         echo "Package NOT OK! Installation is aborted..."


### PR DESCRIPTION
Closes: #11 
Follows good example from: https://github.com/nextcloud/docker/blob/master/Dockerfile
Related to: https://github.com/nextcloud/server/issues/755

Note, I have not tested the script. Ref: https://github.com/owncloud/vm/issues/46

Also includes the OpenPGP key in the vm:

> How would the GPG key be useful after the build is done? I don't see any usecase for it. Even you deleted the whole folder in you code.

The key needs basically no space and is useful for the mentioned reasons. Refs:

* https://github.com/nextcloud/vm/pull/19/commits/78c1f3f1374b6e8f9fc180016e1450afab52f2d8