### PR TITLE
Update Main Websocket error for docker image

### DIFF
--- a/static/collabora.sh
+++ b/static/collabora.sh
@@ -97,8 +97,8 @@ else
   ProxyPassReverse    /hosting/discovery https://127.0.0.1:9980/hosting/discovery
 
   # Main websocket
-  ProxyPass   /lool/ws      wss://127.0.0.1:9980/lool/ws
-
+  ProxyPassMatch   "/lool/(.*)/ws$"      wss://127.0.0.1:9980/lool/$1/ws
+  
   # Admin Console websocket
   ProxyPass   /lool/adminws wss://127.0.0.1:9980/lool/adminws
 


### PR DESCRIPTION
See more: https://help.nextcloud.com/t/updated-collabora-now-unable-to-open-documents/4179/15