### PR TITLE
[WIP] Improve the Collabora script

### DIFF
--- a/static/collabora.sh
+++ b/static/collabora.sh
@@ -117,8 +117,8 @@ else
   SSLHonorCipherOrder     on
 
   # Encoded slashes need to be allowed
-  AllowEncodedSlashes On
-
+  AllowEncodedSlashes NoDecode
+  
   # Container uses a unique non-signed certificate
   SSLProxyEngine On
   SSLProxyVerify None
@@ -138,7 +138,7 @@ else
   ProxyPassReverse    /hosting/discovery https://127.0.0.1:9980/hosting/discovery
 
   # Main websocket
-  ProxyPassMatch   "/lool/(.*)/ws$"      wss://127.0.0.1:9980/lool/$1/ws
+  ProxyPassMatch "/lool/(.*)/ws$" wss://127.0.0.1:9980/lool/$1/ws nocanon
   
   # Admin Console websocket
   ProxyPass   /lool/adminws wss://127.0.0.1:9980/lool/adminws

--- a/static/collabora.sh
+++ b/static/collabora.sh
@@ -109,9 +109,9 @@ else
 
   # SSL configuration, you may want to take the easy route instead and use Lets Encrypt!
   SSLEngine on
-  SSLCertificateChainFile $CERTFILES/$CLEANDOMAIN/chain.pem
-  SSLCertificateFile $CERTFILES/$CLEANDOMAIN/cert.pem
-  SSLCertificateKeyFile $CERTFILES/$CLEANDOMAIN/privkey.pem
+  SSLCertificateChainFile $CERTFILES/$EDITORDOMAIN/chain.pem
+  SSLCertificateFile $CERTFILES/$EDITORDOMAIN/cert.pem
+  SSLCertificateKeyFile $CERTFILES/$EDITORDOMAIN/privkey.pem
   SSLProtocol             all -SSLv2 -SSLv3
   SSLCipherSuite ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
   SSLHonorCipherOrder     on
@@ -171,7 +171,7 @@ sudo service apache2 stop
 cd /etc
 git clone https://github.com/certbot/certbot.git
 cd /etc/certbot
-./letsencrypt-auto certonly --agree-tos --standalone -d $CLEANDOMAIN
+./letsencrypt-auto certonly --agree-tos --standalone -d $EDITORDOMAIN
 # Check if $certfiles exists
 if [ -d "$HTTPS_CONF" ]
 then


### PR DESCRIPTION
I tested the script and there are no script errors, but why get a cert for the main domain? Makes no sense imo.

About using the standard Let's Encrypt scripts... no need as this is only for setting up the subdomain, doesn't have to be that advanced, but improvements are welcome.

Me and @ezraholm50 were discussing that we maybe should start with the Let's Encrypt scripts to setup the SSL config, and then use that address like $1 as we do in test-new.config.sh... It's an idea, but don't know if it's optimal.

Please review and test this script live please @nextcloud/vm

