### PR TITLE
Automated networking

### DIFF
--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -475,7 +475,8 @@ then
     sleep 1
     echo
     CONTEST=$(bash $SCRIPTS/test_connection.sh)
-    if [ "$CONTEST" == "Connected!" ] then
+    if [ "$CONTEST" == "Connected!" ] 
+    then
         echo "Connected!"
         echo
         echo "We will use the DHCP address for now, if you want to change it later then just"

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -477,16 +477,19 @@ then
     CONTEST=$(bash $SCRIPTS/test_connection.sh)
     if [ "$CONTEST" == "Connected!" ] 
     then
-        echo "Connected!"
+        # Connected!
+        echo -e "\e[32m$CONTEST\e[0m"
         echo
         echo "We will use the DHCP address for now, if you want to change it later then just"
-        echo "edit the interfaces file. If you experience any bugs, please report it here:"
+        echo "edit the interfaces file: sudo nano /etc/network/interfaces"
+        echo "If you experience any bugs, please report it here:"
         echo "https://github.com/nextcloud/vm/issues/new"
         echo -e "\e[32m"
         read -p "Press any key to continue..." -n1 -s
         echo -e "\e[0m"
-    else    
-        echo -e "\e[31mNot Connected!\e[0m\nYou should change your settings manually in the next step."
+    else
+        # Not connected!
+        echo -e "\e[31m$CONTEST\e[0m\nYou should change your settings manually in the next step."
         echo -e "\e[32m"
         read -p "Press any key to open /etc/network/interfaces..." -n1 -s
         echo -e "\e[0m"
@@ -500,7 +503,7 @@ then
     ifup $IFACE
     sleep 1
     echo
-    bash $SCRIPTS/test_connection.sh
+    $CONTEST
     sleep 1
 else
     echo "OK, then we will not set a static IP as your VPS provider already have setup the network for you..."

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -479,6 +479,9 @@ then
         echo "We will use the DHCP address for now, if you want to change it later then just"
         echo "edit the interfaces file. If you experience any bugs, please report it here:"
         echo "https://github.com/nextcloud/vm/issues/new"
+        echo -e "\e[32m"
+        read -p "Press any key to continue..." -n1 -s
+        echo -e "\e[0m"
     else    
         echo -e "\e[31mNot Connected!\e[0m\nYou should change your settings manually in the next step."
         echo -e "\e[32m"

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -476,6 +476,8 @@ then
     echo
     CONTEST=$(bash $SCRIPTS/test_connection.sh)
     if [ "$CONTEST" == "Connected!" ] then
+        echo "Connected!"
+        echo
         echo "We will use the DHCP address for now, if you want to change it later then just"
         echo "edit the interfaces file. If you experience any bugs, please report it here:"
         echo "https://github.com/nextcloud/vm/issues/new"

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -478,7 +478,7 @@ then
     if [ "$CONTEST" == "Connected!" ] 
     then
         # Connected!
-        echo -e "\e[32m$CONTEST\e[0m"
+        echo -e "\e[32mConnected!\e[0m"
         echo
         echo "We will use the DHCP address for now, if you want to change it later then just"
         echo "edit the interfaces file: sudo nano /etc/network/interfaces"
@@ -489,7 +489,7 @@ then
         echo -e "\e[0m"
     else
         # Not connected!
-        echo -e "\e[31m$CONTEST\e[0m\nYou should change your settings manually in the next step."
+        echo -e "\e[31mNot Connected\e[0m\nYou should change your settings manually in the next step."
         echo -e "\e[32m"
         read -p "Press any key to open /etc/network/interfaces..." -n1 -s
         echo -e "\e[0m"
@@ -502,8 +502,7 @@ then
     sleep 1
     ifup $IFACE
     sleep 1
-    echo
-    $CONTEST
+    bash $SCRIPTS/test_connection.sh
     sleep 1
 else
     echo "OK, then we will not set a static IP as your VPS provider already have setup the network for you..."

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -474,15 +474,18 @@ then
     echo "Testing if network is OK..."
     sleep 1
     echo
-    bash $SCRIPTS/test_connection.sh
-    sleep 1
-    echo
-    echo -e "\e[0mIf the output is \e[32mConnected! \o/\e[0m everything is working."
-    echo -e "\e[0mIf the output is \e[31mNot Connected!\e[0m you should change\nyour settings manually in the next step."
-    echo -e "\e[32m"
-    read -p "Press any key to open /etc/network/interfaces..." -n1 -s
-    echo -e "\e[0m"
-    nano /etc/network/interfaces
+    CONTEST=$(bash $SCRIPTS/test_connection.sh)
+    if [ "$CONTEST" == "Connected!" ] then
+        echo "We will use the DHCP address for now, if you want to change it later then just"
+        echo "edit the interfaces file. If you experience any bugs, please report it here:"
+        echo "https://github.com/nextcloud/vm/issues/new"
+    else    
+        echo -e "\e[31mNot Connected!\e[0m\nYou should change your settings manually in the next step."
+        echo -e "\e[32m"
+        read -p "Press any key to open /etc/network/interfaces..." -n1 -s
+        echo -e "\e[0m"
+        nano /etc/network/interfaces
+    fi 
     service networking restart
     clear
     echo "Testing if network is OK..."

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -475,7 +475,7 @@ then
     sleep 1
     echo
     CONTEST=$(bash $SCRIPTS/test_connection.sh)
-    if [ "$CONTEST" == "Connected! \o/" ] 
+    if [ "$CONTEST" == "Connected!" ] 
     then
         echo "Connected!"
         echo

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -475,7 +475,7 @@ then
     sleep 1
     echo
     CONTEST=$(bash $SCRIPTS/test_connection.sh)
-    if [ "$CONTEST" == "Connected!" ] 
+    if [ "$CONTEST" == "Connected! \o/" ] 
     then
         echo "Connected!"
         echo

--- a/static/test_connection.sh
+++ b/static/test_connection.sh
@@ -7,5 +7,5 @@ if [ ! -s /tmp/google.idx ]
 then
      echo -e "\e[31mNot Connected!\e[0m"
 else
-    echo -e "Connected!"
+    echo -e "\e[32mConnected!\e[0m"
 fi

--- a/static/test_connection.sh
+++ b/static/test_connection.sh
@@ -5,10 +5,7 @@ WGET="/usr/bin/wget"
 $WGET -q --tries=20 --timeout=10 http://www.google.com -O /tmp/google.idx &> /dev/null
 if [ ! -s /tmp/google.idx ]
 then
-     echo -e "\e[31mNot Connected!"
+     echo -e "\e[31mNot Connected!\e[0m"
 else
-    echo -e "\e[32mConnected! \o/"
+    echo -e "Connected!"
 fi
-
-# Reset colors
-echo -e "\e[0m"


### PR DESCRIPTION
Automates the test_connection.sh script and only prompt nano /etc/network/interfaces when the connection fails. It uses the DHCP connection.