### PR TITLE
try with webroot first

### DIFF
--- a/lets-encrypt/activate-ssl.sh
+++ b/lets-encrypt/activate-ssl.sh
@@ -280,7 +280,28 @@ SSL_CREATE
 fi
 
 ##### START FIRST TRY
+letsencrypt certonly \
+--webroot -w $NCPATH \
+--rsa-key-size 4096 \
+--renew-by-default \
+--agree-tos \
+-d $domain
 
+# Check if $certfiles exists
+if [ -d "$certfiles" ]
+then
+    # Activate new config
+    bash /var/scripts/test-new-config.sh $domain.conf
+    exit 0
+else
+    echo -e "\e[96m"
+    echo -e "It seems like no certs were generated, we do three more try."
+    echo -e "\e[32m"
+    read -p "Press any key to continue... " -n1 -s
+    echo -e "\e[0m"
+fi
+
+##### START SECOND TRY
 # Stop Apache to aviod port conflicts
 a2dissite 000-default.conf
 sudo service apache2 stop
@@ -304,12 +325,13 @@ then
     exit 0
 else
     echo -e "\e[96m"
-    echo -e "It seems like no certs were generated, we do three more tries."
+    echo -e "It seems like no certs were generated, we do two more tries."
     echo -e "\e[32m"
     read -p "Press any key to continue... " -n1 -s
     echo -e "\e[0m"
 fi
-##### START SECOND TRY
+
+##### START THIRD TRY
 # Generate certs
 letsencrypt \
 --rsa-key-size 4096 \
@@ -324,32 +346,12 @@ then
     exit 0
 else
     echo -e "\e[96m"
-    echo -e "It seems like no certs were generated, we do two more tries."
+    echo -e "It seems like no certs were generated, we do one more tries."
     echo -e "\e[32m"
     read -p "Press any key to continue... " -n1 -s
     echo -e "\e[0m"
 fi
-##### START THIRD TRY
-letsencrypt certonly \
---webroot --w $NCPATH \
---rsa-key-size 4096 \
---renew-by-default \
---agree-tos \
--d $domain
 
-# Check if $certfiles exists
-if [ -d "$certfiles" ]
-then
-    # Activate new config
-    bash /var/scripts/test-new-config.sh $domain.conf
-    exit 0
-else
-    echo -e "\e[96m"
-    echo -e "It seems like no certs were generated, we do one more try."
-    echo -e "\e[32m"
-    read -p "Press any key to continue... " -n1 -s
-    echo -e "\e[0m"
-fi
 #### START FORTH TRY
 # Generate certs
 letsencrypt \

--- a/lets-encrypt/activate-ssl.sh
+++ b/lets-encrypt/activate-ssl.sh
@@ -280,6 +280,7 @@ SSL_CREATE
 fi
 
 ##### START FIRST TRY
+
 letsencrypt certonly \
 --webroot -w $NCPATH \
 --rsa-key-size 4096 \
@@ -295,13 +296,14 @@ then
     exit 0
 else
     echo -e "\e[96m"
-    echo -e "It seems like no certs were generated, we do three more try."
+    echo -e "It seems like no certs were generated, we do three more tries."
     echo -e "\e[32m"
     read -p "Press any key to continue... " -n1 -s
     echo -e "\e[0m"
 fi
 
 ##### START SECOND TRY
+
 # Stop Apache to aviod port conflicts
 a2dissite 000-default.conf
 sudo service apache2 stop
@@ -312,7 +314,6 @@ letsencrypt certonly \
 --renew-by-default \
 --agree-tos \
 -d $domain
-
 # Activate Apache again (Disabled during standalone)
 service apache2 start
 a2ensite 000-default.conf
@@ -332,6 +333,7 @@ else
 fi
 
 ##### START THIRD TRY
+
 # Generate certs
 letsencrypt \
 --rsa-key-size 4096 \
@@ -353,6 +355,7 @@ else
 fi
 
 #### START FORTH TRY
+
 # Generate certs
 letsencrypt \
 --apache

--- a/lets-encrypt/activate-ssl.sh
+++ b/lets-encrypt/activate-ssl.sh
@@ -274,6 +274,15 @@ else
     SSLCertificateChainFile $certfiles/$domain/chain.pem
     SSLCertificateFile $certfiles/$domain/cert.pem
     SSLCertificateKeyFile $certfiles/$domain/privkey.pem
+    
+### Let's Encrypt settings ###
+
+    Alias /.well-known/acme-challenge/ "/var/lib/letsencrypt/.well-known/acme-challenge/"
+<Directory "/var/lib/letsencrypt/">
+    AllowOverride None
+    Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
+    Require method GET POST OPTIONS
+</Directory>
 
 </VirtualHost>
 SSL_CREATE

--- a/lets-encrypt/activate-ssl.sh
+++ b/lets-encrypt/activate-ssl.sh
@@ -348,7 +348,7 @@ then
     exit 0
 else
     echo -e "\e[96m"
-    echo -e "It seems like no certs were generated, we do one more tries."
+    echo -e "It seems like no certs were generated, we do one more try."
     echo -e "\e[32m"
     read -p "Press any key to continue... " -n1 -s
     echo -e "\e[0m"

--- a/lets-encrypt/test-new-config.sh
+++ b/lets-encrypt/test-new-config.sh
@@ -65,19 +65,12 @@ DATE='$(date +%Y-%m-%d_%H:%M)'
 IF='if [[ $? -eq 0 ]]'
 cat << CRONTAB > "$SCRIPTS/letsencryptrenew.sh"
 #!/bin/sh
-service apache2 stop
-if ! letsencrypt renew > /var/log/letsencrypt/renew.log 2>&1 ; then
-        echo Automated renewal failed:
-        cat /var/log/letsencrypt/renew.log
-        exit 1
-fi
-service apache2 start
+letsencrypt renew >> /var/log/letsencrypt/renew.log
 $IF
 then
         echo "Let's Encrypt SUCCESS!"--$DATE >> /var/log/letsencrypt/cronjob.log
 else
         echo "Let's Encrypt FAILED!"--$DATE >> /var/log/letsencrypt/cronjob.log
-        reboot
 fi
 CRONTAB
 


### PR DESCRIPTION
One of the benefits with the webroot method is that Apache wont have to stop before renewing the cert. This also makes it less potent to failures as Apache may not start when it's once stopped which means unwanted downtime. This needs to be fixed.