### PR TITLE
Enable HTTP/2 server wide

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -57,6 +57,7 @@ PHPMYADMIN_CONF="/etc/apache2/conf-available/phpmyadmin.conf"
 SECURE="$SCRIPTS/setup_secure_permissions_nextcloud.sh"
 SSL_CONF="/etc/apache2/sites-available/nextcloud_ssl_domain_self_signed.conf"
 HTTP_CONF="/etc/apache2/sites-available/nextcloud_http_domain_self_signed.conf"
+HTTP2_CONF="/etc/apache2/mods-available/http2.conf"
 # Nextcloud version
 [ ! -z "$NC_UPDATE" ] && CURRENTVERSION=$(sudo -u www-data php $NCPATH/occ status | grep "versionstring" | awk '{print $3}')
 NCVERSION=$(curl -s -m 900 $NCREPO/ | sed --silent 's/.*href="nextcloud-\([^"]\+\).zip.asc".*/\1/p' | sort --version-sort | tail -1)

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -411,10 +411,21 @@ SSL_CREATE
     echo "$SSL_CONF was successfully created"
 fi
 
+# Enable HTTP/2 server wide
+touch /etc/apache2/mods-available/http2.conf
+cat << HTTP2_ENABLE > /etc/apache2/mods-available/http2.conf
+<IfModule http2_module>
+        Protocols h2 h2c http/1.1
+        H2Direct on
+</IfModule>
+HTTP2_ENABLE
+echo '"/etc/apache2/mods-available/http2.conf" was successfully created'
+
 # Enable new config
 a2ensite nextcloud_ssl_domain_self_signed.conf
 a2ensite nextcloud_http_domain_self_signed.conf
 a2dissite default-ssl
+a2enmod http2
 service apache2 restart
 
 whiptail --title "Which apps/programs do you want to install?" --checklist --separate-output "" 10 40 3 \

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -412,14 +412,14 @@ SSL_CREATE
 fi
 
 # Enable HTTP/2 server wide
-touch /etc/apache2/mods-available/http2.conf
-cat << HTTP2_ENABLE > /etc/apache2/mods-available/http2.conf
+touch "$HTTP2_CONF"
+cat << HTTP2_ENABLE > "$HTTP2_CONF"
 <IfModule http2_module>
         Protocols h2 h2c http/1.1
         H2Direct on
 </IfModule>
 HTTP2_ENABLE
-echo '"/etc/apache2/mods-available/http2.conf" was successfully created'
+echo "$HTTP2_CONF was successfully created"
 
 # Enable new config
 a2ensite nextcloud_ssl_domain_self_signed.conf

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -411,6 +411,10 @@ SSL_CREATE
     echo "$SSL_CONF was successfully created"
 fi
 
+## Add ask_yes_no here
+
+# if ....
+
 # Enable HTTP/2 server wide
 cat << HTTP2_ENABLE > "$HTTP2_CONF"
 <IfModule http2_module>
@@ -420,11 +424,14 @@ cat << HTTP2_ENABLE > "$HTTP2_CONF"
 HTTP2_ENABLE
 echo "$HTTP2_CONF was successfully created"
 
+a2enmod http2
+
+# fi ...
+
 # Enable new config
 a2ensite nextcloud_ssl_domain_self_signed.conf
 a2ensite nextcloud_http_domain_self_signed.conf
 a2dissite default-ssl
-a2enmod http2
 service apache2 restart
 
 whiptail --title "Which apps/programs do you want to install?" --checklist --separate-output "" 10 40 3 \

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -412,7 +412,6 @@ SSL_CREATE
 fi
 
 # Enable HTTP/2 server wide
-touch "$HTTP2_CONF"
 cat << HTTP2_ENABLE > "$HTTP2_CONF"
 <IfModule http2_module>
         Protocols h2 h2c http/1.1

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -411,22 +411,26 @@ SSL_CREATE
     echo "$SSL_CONF was successfully created"
 fi
 
-## Add ask_yes_no here
+# Enable HTTP/2 server wide, if user decides to
+echo "Your official package repository does not provide an apache2 package with HTTP/2 module included."
+echo "If you like to enable HTTP/2 nevertheless, we can upgrade your apache2 from Ondrejs personal package archive (PPA): https://launchpad.net/~ondrej/+archive/ubuntu/apache2"
+echo "Enabling HTTP/2 can bring a performance advantage, but may also have some compatibility issues."
+echo "E.g. the Nextcloud Spreed video calls app does not yet work with HTTP/2 enabled."
+if [[ "yes" == $(ask_yes_or_no "Do you want to enable HTTP/2 server wide?") ]]
+then
+    add-apt-repository ppa:ondrej/apache2
+    apt update -q4 & spinner_loading
+    apt upgrade apache2
 
-# if ....
-
-# Enable HTTP/2 server wide
-cat << HTTP2_ENABLE > "$HTTP2_CONF"
+    cat << HTTP2_ENABLE > "$HTTP2_CONF"
 <IfModule http2_module>
         Protocols h2 h2c http/1.1
         H2Direct on
 </IfModule>
 HTTP2_ENABLE
-echo "$HTTP2_CONF was successfully created"
-
-a2enmod http2
-
-# fi ...
+    echo "$HTTP2_CONF was successfully created"
+    a2enmod http2
+fi
 
 # Enable new config
 a2ensite nextcloud_ssl_domain_self_signed.conf

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -411,33 +411,36 @@ SSL_CREATE
     echo "$SSL_CONF was successfully created"
 fi
 
+# Enable new config
+a2ensite nextcloud_ssl_domain_self_signed.conf
+a2ensite nextcloud_http_domain_self_signed.conf
+a2dissite default-ssl
+
 # Enable HTTP/2 server wide, if user decides to
-echo "Your official package repository does not provide an apache2 package with HTTP/2 module included."
-echo "If you like to enable HTTP/2 nevertheless, we can upgrade your apache2 from Ondrejs personal package archive (PPA): https://launchpad.net/~ondrej/+archive/ubuntu/apache2"
+echo "Your official package repository does not provide an Apache2 package with HTTP/2 module included."
+echo "If you like to enable HTTP/2 nevertheless, we can upgrade your Apache2 from Ondrejs PPA:"
+echo "https://launchpad.net/~ondrej/+archive/ubuntu/apache2"
 echo "Enabling HTTP/2 can bring a performance advantage, but may also have some compatibility issues."
 echo "E.g. the Nextcloud Spreed video calls app does not yet work with HTTP/2 enabled."
-if [[ "yes" == $(ask_yes_or_no "Do you want to enable HTTP/2 server wide?") ]]
+if [[ "yes" == $(ask_yes_or_no "Do you want to enable HTTP/2 system wide?") ]]
 then
     # Adding PPA
-    add-apt-repository ppa:ondrej/apache2
+    add-apt-repository ppa:ondrej/apache2 -y
     apt update -q4 & spinner_loading
-    apt upgrade -y apache2
-
+    apt upgrade apache2 -y
+    
     # Enable HTTP/2 module & protocol
     cat << HTTP2_ENABLE > "$HTTP2_CONF"
 <IfModule http2_module>
-        Protocols h2 h2c http/1.1
-        H2Direct on
+    Protocols h2 h2c http/1.1
+    H2Direct on
 </IfModule>
 HTTP2_ENABLE
     echo "$HTTP2_CONF was successfully created"
     a2enmod http2
 fi
 
-# Enable new config
-a2ensite nextcloud_ssl_domain_self_signed.conf
-a2ensite nextcloud_http_domain_self_signed.conf
-a2dissite default-ssl
+# Restart Apache2 to enable new config
 service apache2 restart
 
 whiptail --title "Which apps/programs do you want to install?" --checklist --separate-output "" 10 40 3 \

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -418,10 +418,12 @@ echo "Enabling HTTP/2 can bring a performance advantage, but may also have some 
 echo "E.g. the Nextcloud Spreed video calls app does not yet work with HTTP/2 enabled."
 if [[ "yes" == $(ask_yes_or_no "Do you want to enable HTTP/2 server wide?") ]]
 then
+    # Adding PPA
     add-apt-repository ppa:ondrej/apache2
     apt update -q4 & spinner_loading
-    apt upgrade apache2
+    apt upgrade -y apache2
 
+    # Enable HTTP/2 module & protocol
     cat << HTTP2_ENABLE > "$HTTP2_CONF"
 <IfModule http2_module>
         Protocols h2 h2c http/1.1


### PR DESCRIPTION
- In favour of https://help.nextcloud.com/t/http-2-on-apache-2-4-27-debian-9/19885/4?u=michaing
- Since Apache version 2.4.17, "`mod_http2`" is shipped but not enabled by default.
- Even enabled, the HTTP/2 protocol is not used by default by the web server.
- It brings "`/etc/apache2/mods-available/http2.load`" but no "`/etc/apache2/mods-available/http2.conf`", so we can use that to enable/disable the protocol server wide together with the mod, as "`*.load`" and "`*.conf`" are symlinked together into "mods-enabled" and included into "`apache2.conf`".
- "`Protocols h2 h2c http/1.1`" defines the order in which the protocols are prioritize, where "`h2`" stands for HTTP/2 for https/ssl and "`h2c`" for h2**clear**, thus the clear text non ssl/http.
- "`H2Direct on`" enables less overhead on establishing HTTP/2 connections, but might have some compatibility issues. Further discussion/testing about that might be reasonable.
- Further information: https://httpd.apache.org/docs/2.4/mod/mod_http2.html, https://httpd.apache.org/docs/2.4/howto/http2.html