### PR TITLE
DHPARAMS 4096 to allow for IE11/Win7 to work instead of Page Cant Be …

### DIFF
--- a/lets-encrypt/activate-ssl.sh
+++ b/lets-encrypt/activate-ssl.sh
@@ -248,7 +248,7 @@ if [ -d "$CERTFILES" ]
     # Generate DHparams chifer
     if [ ! -f "$DHPARAMS" ]
     then
-        openssl dhparam -dsaparam -out "$DHPARAMS" 8192
+        openssl dhparam -dsaparam -out "$DHPARAMS" 4096
     fi
     # Activate new config
     check_command bash "$SCRIPTS/test-new-config.sh" "$domain.conf"


### PR DESCRIPTION
…Displayed

ssllabs.com shows a standard IE11/Win7 setup will not work. For companies that do not allow alternative popular Browsers this can be a non go for internal company deployment. Lowering the DH to 4096 may alleviate this issue. Below is the ssllabs.com lab results:

IE 11 / Win 7  R		Client does not support DH parameters > 4096 bits
RSA 4096 (SHA256)   |  TLS 1.2  |  TLS_DHE_RSA_WITH_AES_128_GCM_SHA256  |  DH 8192