### PR TITLE
prevents ssl error

### DIFF
--- a/apps/fulltextsearch.sh
+++ b/apps/fulltextsearch.sh
@@ -67,6 +67,7 @@ check_command /etc/init.d/elasticsearch start
 
 # Enable on bootup
 sudo systemctl enable elasticsearch.service
+update-ca-certificates -f
 
 # Install ingest-attachment plugin
 if [ -d /usr/share/elasticsearch ]


### PR DESCRIPTION
By updating ssl cert, this error is prevented in case previous java configuration was performed on the same server installing ES.