### PR TITLE
Fix_UniqueConstraintViolationException-PostgreSQL

### DIFF
--- a/static/redis-server-ubuntu16.sh
+++ b/static/redis-server-ubuntu16.sh
@@ -75,15 +75,15 @@ sed -i "s|);||g" $NCPATH/config/config.php
 
 # Add the needed config to Nextclouds config.php
 cat <<ADD_TO_CONFIG >> $NCPATH/config/config.php
-  'memcache.local' => '\\OC\\Memcache\\Redis',
+  'memcache.local' => '\OC\Memcache\Redis',
   'filelocking.enabled' => true,
-  'memcache.distributed' => '\\OC\\Memcache\\Redis',
-  'memcache.locking' => '\\OC\\Memcache\\Redis',
+  'memcache.distributed' => '\OC\Memcache\Redis',
+  'memcache.locking' => '\OC\Memcache\Redis',
   'redis' =>
   array (
     'host' => '$REDIS_SOCK',
     'port' => 0,
-    'timeout' => 0,
+    'timeout' => 1.5,
     'dbindex' => 0,
     'password' => '$REDIS_PASS',
   ),

--- a/static/redis-server-ubuntu16.sh
+++ b/static/redis-server-ubuntu16.sh
@@ -75,15 +75,15 @@ sed -i "s|);||g" $NCPATH/config/config.php
 
 # Add the needed config to Nextclouds config.php
 cat <<ADD_TO_CONFIG >> $NCPATH/config/config.php
-  'memcache.local' => '\OC\Memcache\Redis',
+  'memcache.local' => '\\OC\\Memcache\\Redis',
   'filelocking.enabled' => true,
-  'memcache.distributed' => '\OC\Memcache\Redis',
-  'memcache.locking' => '\OC\Memcache\Redis',
+  'memcache.distributed' => '\\OC\\Memcache\\Redis',
+  'memcache.locking' => '\\OC\\Memcache\\Redis',
   'redis' =>
   array (
     'host' => '$REDIS_SOCK',
     'port' => 0,
-    'timeout' => 1.5,
+    'timeout' => 0.5,
     'dbindex' => 0,
     'password' => '$REDIS_PASS',
   ),


### PR DESCRIPTION
This fixes the Doctrine\DBAL\Exception\UniqueConstraintViolationException (Deadlock oc_filecache) error when trying to modify several files at a time.

Tested on 3 Nextcloud servers (2 PostgreSQL, 1 MariaDB). Still trying to see if I can re-create the same issue but so far seems to be resolved.