### PR TITLE
fix adduser error

### DIFF
--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -153,7 +153,7 @@ Please create a user with sudo permissions and the run this command:
 sudo -u [user-with-sudo-permissions] sudo bash /var/scripts/nextcloud-startup-script.sh
 
 We will do this for you when you hit OK."
-       run_static_script adduser $SCRIPTS/nextcloud-startup-script.sh
+       run_static_script adduser nextcloud-startup-script
        else
 msg_box "You probably see this message if the user 'ncadmin' does not exist on the system,
 which could be the case if you are running directly from the scripts and not the VM.

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -66,7 +66,7 @@ ram_check 2 Nextcloud
 cpu_check 1 Nextcloud
 
 # Create new current user
-run_static_script adduser nextcloud_install_production.sh
+run_static_script adduser nextcloud_install_production
 
 # Check distrobution and version
 check_distro_version

--- a/static/adduser.sh
+++ b/static/adduser.sh
@@ -35,6 +35,6 @@ The preferred user is 'ncadmin'."
             sudo passwd "$NEWUSER" && break
         done
         download_static_script "$1"
-        sudo -u "$NEWUSER" sudo bash "$SCRIPTS"/"$1.sh"
+        sudo -u "$NEWUSER" sudo bash "$SCRIPTS"/"$1".sh
     fi
 fi

--- a/static/adduser.sh
+++ b/static/adduser.sh
@@ -34,6 +34,7 @@ The preferred user is 'ncadmin'."
         do
             sudo passwd "$NEWUSER" && break
         done
-        sudo -u "$NEWUSER" sudo bash "$1"
+        download_static_script $1
+        sudo -u "$NEWUSER" sudo bash "$SCRIPTS"/"$1.sh"
     fi
 fi

--- a/static/adduser.sh
+++ b/static/adduser.sh
@@ -34,7 +34,7 @@ The preferred user is 'ncadmin'."
         do
             sudo passwd "$NEWUSER" && break
         done
-        download_static_script $1
+        download_static_script "$1"
         sudo -u "$NEWUSER" sudo bash "$SCRIPTS"/"$1.sh"
     fi
 fi


### PR DESCRIPTION
When running nextcloud_install_production.sh you got this `bash: : No such file or directory` when running as root and wanted to add a new sudo user.

