### PR TITLE
DigitalOcean support #645 + additional changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## Build your own VM, or install on a VPS
 DigitalOcean example: https://youtu.be/LlqY5Y6P9Oc<br>
-Please note that you have to add a second storage and [rename](https://www.digitalocean.com/docs/volumes/how-to/create-and-attach/) it to `vdb` before you can run the script.
+The script will mount and format the drive. Please select Manually Format & Mount when adding the second volume.
 
 #### Minimum requirements:
 * A clean [Ubuntu Server 18.04.X](http://cdimage.ubuntu.com/releases/18.04/release/) using the alternative installer

--- a/static/format-sdb.sh
+++ b/static/format-sdb.sh
@@ -20,7 +20,6 @@ umount /mnt/* &> /dev/null
 # mkdir if not existing
 mkdir -p "$MOUNT_"
 
-
 # Check what Hypervisor disks are available
 SYSVENDOR=$(cat /sys/devices/virtual/dmi/id/sys_vendor)
 if [ "$SYSVENDOR" == "VMware, Inc." ];
@@ -56,6 +55,20 @@ msg_box "It seems like you didn't mount a second disk.
 To be able to put the DATA on a second drive formatted as ZFS you need to add a second disk to this server.
 
 This script will now exit. Please mount a second disk and start over."
+exit 1
+fi
+
+# Get the name of the drive
+DISKTYPE=$(fdisk -l | grep $DEVTYPE | awk '{print $2}' | cut -d ":" -f1 | head -1)
+if [ "$DISKTYPE" != "/dev/$DEVTYPE" ]
+then
+msg_box "It seems like your $SYSNAME secondary volume (/dev/$DEVTYPE) does not exist.
+This script requires that you mount a second drive to hold the data.
+
+Please shutdown the server and mount a second drive, then start this script again.
+
+If you want help you can buy support in our shop:
+https://shop.hanssonit.se/product/premium-support-per-30-minutes/"
 exit 1
 fi
 
@@ -98,20 +111,6 @@ if isDevPartOfZFS "$DEVTYPE";
 then
 msg_box "/dev/$DEVTYPE is a member of a ZFS pool and needs to be removed from any zpool before you can run this script."
     exit 1
-fi
-
-# Get the name of the drive
-DISKTYPE=$(fdisk -l | grep $DEVTYPE | awk '{print $2}' | cut -d ":" -f1 | head -1)
-if [ "$DISKTYPE" != "/dev/$DEVTYPE" ]
-then
-msg_box "It seems like your $SYSNAME secondary volume (/dev/$DEVTYPE) does not exist.
-This script requires that you mount a second drive to hold the data.
-
-Please shutdown the server and mount a second drive, then start this script again.
-
-If you want help you can buy support in our shop:
-https://shop.hanssonit.se/product/premium-support-per-30-minutes/"
-exit 1
 fi
 
 if lsblk -l -n | grep -v mmcblk | grep disk | awk '{ print $1 }' | tail -1 > /dev/null

--- a/static/format-sdb.sh
+++ b/static/format-sdb.sh
@@ -47,9 +47,15 @@ elif [ "$SYSVENDOR" == "DigitalOcean" ];
 then
     SYSNAME="DigitalOcean"
     DEVTYPE=sda
-else
+elif partprobe /dev/sdb &>/dev/null;
     SYSNAME="machines"
     DEVTYPE=sdb
+else
+msg_box "It seems like you didn't mount a second disk. 
+To be able to put the DATA on a second drive formatted as ZFS you need to add a second disk to this server.
+
+This sript will now exit. Please mount a second disk and start over."
+exit 1
 fi
 
 # Check if ZFS utils are installed
@@ -103,7 +109,7 @@ This script requires that you mount a second drive to hold the data.
 Please shutdown the server and mount a second drive, then start this script again.
 
 If you want help you can buy support in our shop:
-https://shop.techandme.se/index.php/product/premium-support-per-30-minutes/"
+https://shop.hanssonit.se/product/premium-support-per-30-minutes/"
 exit 1
 fi
 

--- a/static/format-sdb.sh
+++ b/static/format-sdb.sh
@@ -27,9 +27,9 @@ if [ "$SYSVENDOR" == "VMware, Inc." ];
 then
     SYSNAME="VMware"
     DEVTYPE=sdb
-elif [ "$SYSVENDOR" == "HyperV" ];
+elif [ "$SYSVENDOR" == "Microsoft Corporation" ];
 then
-    SYSNAME="$SYSVENDOR"
+    SYSNAME="Hyper-V"
     DEVTYPE=sdb
 elif [ "$SYSVENDOR" == "innotek GmbH" ];
 then
@@ -37,15 +37,15 @@ then
     DEVTYPE=sdb
 elif [ "$SYSVENDOR" == "Xen" ];
 then
-    SYSNAME="$SYSVENDOR/XCP-NG"
+    SYSNAME="Xen/XCP-NG"
     DEVTYPE=xvdb
 elif [ "$SYSVENDOR" == "QEMU" ];
 then
-    SYSNAME="$SYSVENDOR/KVM"
+    SYSNAME="KVM/QEMU"
     DEVTYPE=vdb
 elif [ "$SYSVENDOR" == "DigitalOcean" ];
 then
-    SYSNAME="$SYSVENDOR"
+    SYSNAME="DigitalOcean"
     DEVTYPE=sda
 else
     SYSNAME="machines"

--- a/static/format-sdb.sh
+++ b/static/format-sdb.sh
@@ -54,7 +54,7 @@ else
 msg_box "It seems like you didn't mount a second disk. 
 To be able to put the DATA on a second drive formatted as ZFS you need to add a second disk to this server.
 
-This sript will now exit. Please mount a second disk and start over."
+This script will now exit. Please mount a second disk and start over."
 exit 1
 fi
 

--- a/static/format-sdb.sh
+++ b/static/format-sdb.sh
@@ -22,21 +22,34 @@ mkdir -p "$MOUNT_"
 
 
 # Check what Hypervisor disks are available
-if partprobe /dev/sdb &>/dev/null;	#HyperV, VMware, VirtualBox Hypervisors
+SYSVENDOR=$(cat /sys/devices/virtual/dmi/id/sys_vendor)
+if [ "$SYSVENDOR" == "VMware, Inc." ];
 then
+    SYSNAME="VMware"
     DEVTYPE=sdb
-elif partprobe /dev/xvdb &>/dev/null;	#Xen Hypervisors
+elif [ "$SYSVENDOR" == "HyperV" ];
 then
+    SYSNAME="$SYSVENDOR"
+    DEVTYPE=sdb
+elif [ "$SYSVENDOR" == "innotek GmbH" ];
+then
+    SYSNAME="VirtualBox"
+    DEVTYPE=sdb
+elif [ "$SYSVENDOR" == "Xen" ];
+then
+    SYSNAME="$SYSVENDOR/XCP-NG"
     DEVTYPE=xvdb
-elif partprobe /dev/vdb &>/dev/null;	#KVM Hypervisor
+elif [ "$SYSVENDOR" == "QEMU" ];
 then
+    SYSNAME="$SYSVENDOR/KVM"
     DEVTYPE=vdb
+elif [ "$SYSVENDOR" == "DigitalOcean" ];
+then
+    SYSNAME="$SYSVENDOR"
+    DEVTYPE=sda
 else
-msg_box "It seems like you didn't mount a second disk. 
-To be able to put the DATA on a second drive formatted as ZFS you need to add a second disk to this server.
-
-This script will now exit. Please mount a second disk and start over."
-exit 1
+    SYSNAME="machines"
+    DEVTYPE=sdb
 fi
 
 # Check if ZFS utils are installed
@@ -84,7 +97,7 @@ fi
 DISKTYPE=$(fdisk -l | grep $DEVTYPE | awk '{print $2}' | cut -d ":" -f1 | head -1)
 if [ "$DISKTYPE" != "/dev/$DEVTYPE" ]
 then
-msg_box "It seems like /dev/$DEVTYPE does not exist.
+msg_box "It seems like your $SYSNAME secondary volume ($DISKTYPE) does not exist.
 This script requires that you mount a second drive to hold the data.
 
 Please shutdown the server and mount a second drive, then start this script again.
@@ -96,7 +109,7 @@ fi
 
 if lsblk -l -n | grep -v mmcblk | grep disk | awk '{ print $1 }' | tail -1 > /dev/null
 then
-msg_box "Formatting $DISKTYPE when you hit OK.
+msg_box "Formatting your $SYSNAME secondary volume ($DISKTYPE) when you hit OK.
 
 *** WARNING: ALL YOUR DATA WILL BE ERASED! ***"
     if zpool list | grep "$LABEL_" > /dev/null

--- a/static/format-sdb.sh
+++ b/static/format-sdb.sh
@@ -97,7 +97,7 @@ fi
 DISKTYPE=$(fdisk -l | grep $DEVTYPE | awk '{print $2}' | cut -d ":" -f1 | head -1)
 if [ "$DISKTYPE" != "/dev/$DEVTYPE" ]
 then
-msg_box "It seems like your $SYSNAME secondary volume ($DISKTYPE) does not exist.
+msg_box "It seems like your $SYSNAME secondary volume (/dev/$DEVTYPE) does not exist.
 This script requires that you mount a second drive to hold the data.
 
 Please shutdown the server and mount a second drive, then start this script again.

--- a/static/format-sdb.sh
+++ b/static/format-sdb.sh
@@ -48,6 +48,7 @@ then
     SYSNAME="DigitalOcean"
     DEVTYPE=sda
 elif partprobe /dev/sdb &>/dev/null;
+then
     SYSNAME="machines"
     DEVTYPE=sdb
 else


### PR DESCRIPTION
Modified the device detection to check what System Vendor the hypervisor belongs to and assign names and disks accordingly.

Modified formatting msg_box to display vendor as well as device for example;
Formatting your VMware secondary volume (dev/sdb) when you hit OK.

Modified cannot find disk msg_box to display vendor as well as device for example;
It seems like your VMware secondary volume (dev/sdb) does not exist.

Removed else msg_box from "Check what Hypervisor disks are available" section as it is also checks at Line 96-108, unsure why we would need this twice and instead added else sdb for unsupported hypervisors or physical machines