### PR TITLE
cannot stat /etc/netplan/01-netcfg.yaml

### DIFF
--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -103,10 +103,14 @@ You must have a working network connection to run this script.
 
 You will now be provided with the option to set a static IP manually instead."
 
-    # Copy old interfaces file
-msg_box "Copying old netplan.io config file file to:
-/tmp/01-netcfg.yaml_backup"
-    check_command cp -v /etc/netplan/01-netcfg.yaml /tmp/01-netcfg.yaml_backup
+    # Copy old interfaces files
+msg_box "Copying old netplan.io config files file to:
+/tmp/netplan_io_backup/"
+    if [ -d /etc/netplan/ ] 
+    then
+        mkdir -p /tmp/netplan_io_backup
+        check_command cp -vR /etc/netplan/* /tmp/netplan_io_backup/
+    fi
 
     # Ask for IP address
 cat << ENTERIP

--- a/static/static_ip.sh
+++ b/static/static_ip.sh
@@ -16,7 +16,7 @@ debug_mode
 
 clear
 
-# Copy old interfaces file
+# Copy old interfaces files
 msg_box "Copying old netplan.io config files file to:
 
 /tmp/netplan_io_backup/"

--- a/static/static_ip.sh
+++ b/static/static_ip.sh
@@ -17,10 +17,14 @@ debug_mode
 clear
 
 # Copy old interfaces file
-msg_box "Copying old netplan.io config file file to:
+msg_box "Copying old netplan.io config files file to:
 
-/tmp/01-netcfg.yaml_backup"
-[[ -f /etc/netplan/01-netcfg.yaml ]] && check_command cp -v /etc/netplan/01-netcfg.yaml /tmp/01-netcfg.yaml_backup
+/tmp/netplan_io_backup/"
+if [ -d /etc/netplan/ ] 
+then
+    mkdir -p /tmp/netplan_io_backup
+    check_command cp -vR /etc/netplan/* /tmp/netplan_io_backup/
+fi
 
 echo
 while true

--- a/static/static_ip.sh
+++ b/static/static_ip.sh
@@ -20,7 +20,7 @@ clear
 msg_box "Copying old netplan.io config file file to:
 
 /tmp/01-netcfg.yaml_backup"
-check_command cp -v /etc/netplan/01-netcfg.yaml /tmp/01-netcfg.yaml_backup
+[[ -f /etc/netplan/01-netcfg.yaml ]] && check_command cp -v /etc/netplan/01-netcfg.yaml /tmp/01-netcfg.yaml_backup
 
 echo
 while true


### PR DESCRIPTION
On my system the file /etc/netplan/01-netcfg.yaml is not available after sudo apt install netplan.io. 
We should check if the file exists befor making a backup, otherwise the script exists without a real reason.