### PR TITLE
enabledPreviewProviders not correctly set

### DIFF
--- a/apps/previewgenerator.sh
+++ b/apps/previewgenerator.sh
@@ -24,28 +24,28 @@ if [ -d "$NC_APPS_PATH/previewgenerator" ]
 then
     # Enable previews (remove the # to enable the specific preview)
     occ_command config:system:set enable_previews --value=true --type=boolean
-    occ_command config:system:set preview_libreoffice_path --value='/usr/bin/libreoffice'
-#    occ_command config:system:set enabledPreviewProviders 0 --value='OC\\Preview\\PNG'
-#    occ_command config:system:set enabledPreviewProviders 1 --value='OC\\Preview\\JPEG'
-#    occ_command config:system:set enabledPreviewProviders 2 --value='OC\\Preview\\GIF'
-#    occ_command config:system:set enabledPreviewProviders 3 --value='OC\\Preview\\BMP'
-#    occ_command config:system:set enabledPreviewProviders 4 --value='OC\\Preview\\XBitmap'
-#    occ_command config:system:set enabledPreviewProviders 5 --value='OC\\Preview\\MarkDown'
-#    occ_command config:system:set enabledPreviewProviders 6 --value='OC\\Preview\\MP3'
-#    occ_command config:system:set enabledPreviewProviders 7 --value='OC\\Preview\\TXT'
-#    occ_command config:system:set enabledPreviewProviders 8 --value='OC\\Preview\\Illustrator'
-#    occ_command config:system:set enabledPreviewProviders 9 --value='OC\\Preview\\Movie'
-#    occ_command config:system:set enabledPreviewProviders 10 --value='OC\\Preview\\MSOffice2003'
-#    occ_command config:system:set enabledPreviewProviders 11 --value='OC\\Preview\\MSOffice2007'
-#    occ_command config:system:set enabledPreviewProviders 12 --value='OC\\Preview\\MSOfficeDoc'
-#    occ_command config:system:set enabledPreviewProviders 13 --value='OC\\Preview\\OpenDocument'
-#    occ_command config:system:set enabledPreviewProviders 14 --value='OC\\Preview\\PDF'
-#    occ_command config:system:set enabledPreviewProviders 15 --value='OC\\Preview\\Photoshop'
-#    occ_command config:system:set enabledPreviewProviders 16 --value='OC\\Preview\\Postscript'
-#    occ_command config:system:set enabledPreviewProviders 17 --value='OC\\Preview\\StarOffice'
-#    occ_command config:system:set enabledPreviewProviders 18 --value='OC\\Preview\\SVG'
-#    occ_command config:system:set enabledPreviewProviders 19 --value='OC\\Preview\\TIFF'
-#    occ_command config:system:set enabledPreviewProviders 20 --value='OC\\Preview\\Font'
+    occ_command config:system:set preview_libreoffice_path --value="/usr/bin/libreoffice"
+#    occ_command config:system:set enabledPreviewProviders 0 --value="OC\\Preview\\PNG"
+#    occ_command config:system:set enabledPreviewProviders 1 --value="OC\\Preview\\JPEG"
+#    occ_command config:system:set enabledPreviewProviders 2 --value="OC\\Preview\\GIF"
+#    occ_command config:system:set enabledPreviewProviders 3 --value="OC\\Preview\\BMP"
+#    occ_command config:system:set enabledPreviewProviders 4 --value="OC\\Preview\\XBitmap"
+#    occ_command config:system:set enabledPreviewProviders 5 --value="OC\\Preview\\MarkDown"
+#    occ_command config:system:set enabledPreviewProviders 6 --value="OC\\Preview\\MP3"
+#    occ_command config:system:set enabledPreviewProviders 7 --value="OC\\Preview\\TXT"
+#    occ_command config:system:set enabledPreviewProviders 8 --value="OC\\Preview\\Illustrator"
+#    occ_command config:system:set enabledPreviewProviders 9 --value="OC\\Preview\\Movie"
+#    occ_command config:system:set enabledPreviewProviders 10 --value="OC\\Preview\\MSOffice2003"
+#    occ_command config:system:set enabledPreviewProviders 11 --value="OC\\Preview\\MSOffice2007"
+#    occ_command config:system:set enabledPreviewProviders 12 --value="OC\\Preview\\MSOfficeDoc"
+#    occ_command config:system:set enabledPreviewProviders 13 --value="OC\\Preview\\OpenDocument"
+#    occ_command config:system:set enabledPreviewProviders 14 --value="OC\\Preview\\PDF"
+#    occ_command config:system:set enabledPreviewProviders 15 --value="OC\\Preview\\Photoshop"
+#    occ_command config:system:set enabledPreviewProviders 16 --value="OC\\Preview\\Postscript"
+#    occ_command config:system:set enabledPreviewProviders 17 --value="OC\\Preview\\StarOffice"
+#    occ_command config:system:set enabledPreviewProviders 18 --value="OC\\Preview\\SVG"
+#    occ_command config:system:set enabledPreviewProviders 19 --value="OC\\Preview\\TIFF"
+#    occ_command config:system:set enabledPreviewProviders 20 --value="OC\\Preview\\Font"
     
     # Set aspect ratio
     occ_command config:app:set --value="32 64 1024"  previewgenerator squareSizes


### PR DESCRIPTION
I guess nobody has ever tested this but setting a string value needs to be done with double quotes.

Otherwise nextcloud config will have four backslashes instead of two (see screenshots below).

[nextcloud occ command](https://docs.nextcloud.com/server/14/admin_manual/configuration_server/occ_command.html#setting-a-single-configuration-value)
Test:
![grafik](https://user-images.githubusercontent.com/13244552/49757270-5088e480-fcbc-11e8-93b1-f35a7d466e39.png)

![grafik](https://user-images.githubusercontent.com/13244552/49757241-3cdd7e00-fcbc-11e8-9065-a2992b937436.png)

![grafik](https://user-images.githubusercontent.com/13244552/49757390-9776da00-fcbc-11e8-8634-943d7a94c85d.png)


![grafik](https://user-images.githubusercontent.com/13244552/49757370-8c23ae80-fcbc-11e8-8313-aec4f568bda3.png)
