### PR TITLE
Don't fail hard when app is not installable 

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -540,13 +540,13 @@ if [ ! -d "$NC_APPS_PATH/$1" ]
 then
     echo "Installing $1..."
 	# occ_command not possible here because it uses check_command and will exit if occ_command fails
-	result=$(sudo -u www-data php /var/www/nextcloud/occ app:install "$1")
+	result=$(sudo -u www-data php ${NCPATH}/occ app:install "$1")
 	if [ "$result" = "Error: Could not download app $1" ]
 	then
 msg_box "$result
 Maybe the app is not compatible with the current installed nextcloud version.
 You can try to install the app manually after the script has finished with the following command:
-'sudo -u www-data php /var/www/nextcloud/occ app:install $1'"
+'sudo -u www-data php ${NCPATH}/occ app:install $1'"
 	# Now return to not enable an app which has not been installed.
 	return 0
 	fi

--- a/lib.sh
+++ b/lib.sh
@@ -540,19 +540,16 @@ if [ ! -d "$NC_APPS_PATH/$1" ]
 then
     echo "Installing $1..."
     # occ_command not possible here because it uses check_command and will exit if occ_command fails
-    result=$(occ_command app:install "$1")
+    result=$(sudo -u www-data php ${NCPATH}/occ app:install "$1")
     if [ "$result" = "Error: Could not download app $1" ]
     then
-msg_box "$result
-The app could not be installed. 
+msg_box "The $1 app could not be installed.
+Probably it's not compatible with $(occ_command -V).
 
-Probably it's not compatible with the currently installed Nextcloud version.
 You can try to install the app manually after the script has finished,
 or when a new version of the app is released with the following command:
 
 'sudo -u www-data php ${NCPATH}/occ app:install $1'"
-        # Now return to not enable an app which has not been installed.
-        return 0
     fi
 fi
 

--- a/lib.sh
+++ b/lib.sh
@@ -539,7 +539,17 @@ install_and_enable_app() {
 if [ ! -d "$NC_APPS_PATH/$1" ]
 then
     echo "Installing $1..."
-    occ_command app:install "$1"
+	# occ_command not possible here because it uses check_command and will exit if occ_command fails
+	result=$(sudo -u www-data php /var/www/nextcloud/occ app:install "$1")
+	if [ "$result" = "Error: Could not download app $1" ]
+	then
+msg_box "$result
+Maybe the app is not compatible with the current installed nextcloud version.
+You can try to install the app manually after the script has finished with the following command:
+'sudo -u www-data php /var/www/nextcloud/occ app:install $1'"
+	# Now return to not enable an app which has not been installed.
+	return 0
+	fi
 fi
 
 # Enable $1

--- a/lib.sh
+++ b/lib.sh
@@ -539,17 +539,21 @@ install_and_enable_app() {
 if [ ! -d "$NC_APPS_PATH/$1" ]
 then
     echo "Installing $1..."
-	# occ_command not possible here because it uses check_command and will exit if occ_command fails
-	result=$(sudo -u www-data php ${NCPATH}/occ app:install "$1")
-	if [ "$result" = "Error: Could not download app $1" ]
-	then
+    # occ_command not possible here because it uses check_command and will exit if occ_command fails
+    result=$(occ_command app:install "$1")
+    if [ "$result" = "Error: Could not download app $1" ]
+    then
 msg_box "$result
-Maybe the app is not compatible with the current installed nextcloud version.
-You can try to install the app manually after the script has finished with the following command:
+The app could not be installed. 
+
+Probably it's not compatible with the currently installed Nextcloud version.
+You can try to install the app manually after the script has finished,
+or when a new version of the app is released with the following command:
+
 'sudo -u www-data php ${NCPATH}/occ app:install $1'"
-	# Now return to not enable an app which has not been installed.
-	return 0
-	fi
+        # Now return to not enable an app which has not been installed.
+        return 0
+    fi
 fi
 
 # Enable $1


### PR DESCRIPTION
Prevent script from failing if NC app can not be installed due to wrong max-version of app (may happen if we move to a newer release of NC) or due to false app name (which should never happen).