### PR TITLE
remove duplicate chain

### DIFF
--- a/apps/fail2ban.sh
+++ b/apps/fail2ban.sh
@@ -59,6 +59,9 @@ failregex = ^.*Login failed: '.*' \(Remote IP: '<HOST>'.*$
 ignoreregex =
 NCONF
 
+# Disable default Debian sshd chain
+sed -i 's/true/false/' /etc/fail2ban/jail.d/defaults-debian.conf 
+
 # Create jail.local file
 cat << FCONF > /etc/fail2ban/jail.local
 # The DEFAULT allows a global definition of the options. They can be overridden


### PR DESCRIPTION
The debian default chain is causing the ssh chain content to be
duplicated in sshd resulting in duplicate sets of rules