### PR TITLE
check if redis.so is enabled

### DIFF
--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -93,6 +93,27 @@ then
     restart_webserver
 fi
 
+# Check if redis.so is enabled
+if [ -f /etc/php/7.2/apache2/php.ini ]
+then
+    if ! [ "$(grep -R redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+    then
+    echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
+elif [ -f /etc/php/7.2/fpm/php.ini ]
+then
+        if ! [ "$(grep -R redis.so /etc/php/7.2/fpm/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+        then
+            echo "extension=redis.so" >> /etc/php/7.2/fpm/php.ini
+elif [ -f /etc/php/7.0/apache2/php.ini ]
+then
+            if ! [ "$(grep -R redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+            then
+                echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
+            fi
+        fi
+    fi
+fi
+
 # Update adminer
 if [ -d $ADMINERDIR ]
 then

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -62,7 +62,6 @@ then
         bash /usr/src/netdata.git/netdata-updater.sh
     fi
 fi
-#!/bin/bash
 
 # Update Redis PHP extension
 print_text_in_color "$ICyan" "Trying to upgrade the Redis PECL extenstion..."

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -110,7 +110,7 @@ then
     pecl channel-update pecl.php.net
     yes no | pecl upgrade redis
     service redis-server restart
-        # Check if redis.so is enabled
+    # Check if redis.so is enabled
     if [ -f /etc/php/7.2/apache2/php.ini ]
     then
         if ! [ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -79,24 +79,17 @@ then
     yes no | pecl install redis
     service redis-server restart
     # Check if redis.so is enabled
-    if [ -f /etc/php/7.2/apache2/php.ini ]
+    # PHP 7.0 apache
+    if [ -f /etc/php/7.0/apache2/php.ini ]
     then
-        if ! [ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
-        then
-        echo "extension=extension=redis.so" >> /etc/php/7.2/apache2/php.ini
+        ! [[ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
+    # PHP 7.2 apache
+    elif [ -f /etc/php/7.0/apache2/php.ini ]
+        ! [[ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
+    # PHP 7.2 fpm
     elif [ -f "$PHP_INI" ]
     then
-            if ! [ "$(grep -R extension=redis.so $PHP_INI)" == "extension=redis.so" ] > /dev/null 2>&1
-            then
-                echo "extension=redis.so" >> "$PHP_INI"
-    elif [ -f /etc/php/7.0/apache2/php.ini ]
-    then
-                if ! [ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
-                then
-                    echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
-                fi
-            fi
-        fi
+        ! [[ "$(grep -R extension=redis.so $PHP_INI)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> "$PHP_INI"
     fi
     restart_webserver
 elif pecl list | grep redis >/dev/null 2>&1
@@ -111,24 +104,17 @@ then
     yes no | pecl upgrade redis
     service redis-server restart
     # Check if redis.so is enabled
-    if [ -f /etc/php/7.2/apache2/php.ini ]
+    # PHP 7.0 apache
+    if [ -f /etc/php/7.0/apache2/php.ini ]
     then
-        if ! [ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
-        then
-        echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
+        ! [[ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
+    # PHP 7.2 apache
+    elif [ -f /etc/php/7.0/apache2/php.ini ]
+        ! [[ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
+    # PHP 7.2 fpm
     elif [ -f "$PHP_INI" ]
     then
-            if ! [ "$(grep -R extension=redis.so $PHP_INI)" == "extension=redis.so" ] > /dev/null 2>&1
-            then
-                echo "extension=redis.so" >> "$PHP_INI"
-    elif [ -f /etc/php/7.0/apache2/php.ini ]
-    then
-                if ! [ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
-                then
-                    echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
-                fi
-            fi
-        fi
+        ! [[ "$(grep -R extension=redis.so $PHP_INI)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> "$PHP_INI"
     fi
     restart_webserver
 fi

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -133,8 +133,6 @@ then
     restart_webserver
 fi
 
-
-
 # Update adminer
 if [ -d $ADMINERDIR ]
 then

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -85,6 +85,7 @@ then
         ! [[ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
     # PHP 7.2 apache
     elif [ -f /etc/php/7.0/apache2/php.ini ]
+    then
         ! [[ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
     # PHP 7.2 fpm
     elif [ -f "$PHP_INI" ]
@@ -110,11 +111,12 @@ then
         ! [[ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
     # PHP 7.2 apache
     elif [ -f /etc/php/7.0/apache2/php.ini ]
+    then
         ! [[ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
     # PHP 7.2 fpm
     elif [ -f "$PHP_INI" ]
     then
-        ! [[ "$(grep -R extension=redis.so $PHP_INI)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> "$PHP_INI"
+        ! [[ "$(grep -R extension=redis.so "$PHP_INI")" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> "$PHP_INI"
     fi
     restart_webserver
 fi

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -82,17 +82,17 @@ then
     # Check if redis.so is enabled
     if [ -f /etc/php/7.2/apache2/php.ini ]
     then
-        if ! [ "$(grep -R redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+        if ! [ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
         then
-        echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
-    elif [ -f /etc/php/7.2/fpm/php.ini ]
+        echo "extension=extension=redis.so" >> /etc/php/7.2/apache2/php.ini
+    elif [ -f "$PHP_INI" ]
     then
-            if ! [ "$(grep -R redis.so /etc/php/7.2/fpm/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+            if ! [ "$(grep -R extension=redis.so $PHP_INI)" == "extension=redis.so" ] > /dev/null 2>&1
             then
-                echo "extension=redis.so" >> /etc/php/7.2/fpm/php.ini
+                echo "extension=redis.so" >> "$PHP_INI"
     elif [ -f /etc/php/7.0/apache2/php.ini ]
     then
-                if ! [ "$(grep -R redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+                if ! [ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
                 then
                     echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
                 fi
@@ -114,17 +114,17 @@ then
         # Check if redis.so is enabled
     if [ -f /etc/php/7.2/apache2/php.ini ]
     then
-        if ! [ "$(grep -R redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+        if ! [ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
         then
         echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
-    elif [ -f /etc/php/7.2/fpm/php.ini ]
+    elif [ -f "$PHP_INI" ]
     then
-            if ! [ "$(grep -R redis.so /etc/php/7.2/fpm/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+            if ! [ "$(grep -R extension=redis.so $PHP_INI)" == "extension=redis.so" ] > /dev/null 2>&1
             then
-                echo "extension=redis.so" >> /etc/php/7.2/fpm/php.ini
+                echo "extension=redis.so" >> "$PHP_INI"
     elif [ -f /etc/php/7.0/apache2/php.ini ]
     then
-                if ! [ "$(grep -R redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+                if ! [ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
                 then
                     echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
                 fi

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -62,6 +62,7 @@ then
         bash /usr/src/netdata.git/netdata-updater.sh
     fi
 fi
+#!/bin/bash
 
 # Update Redis PHP extension
 print_text_in_color "$ICyan" "Trying to upgrade the Redis PECL extenstion..."
@@ -78,6 +79,26 @@ then
     pecl channel-update pecl.php.net
     yes no | pecl install redis
     service redis-server restart
+    # Check if redis.so is enabled
+    if [ -f /etc/php/7.2/apache2/php.ini ]
+    then
+        if ! [ "$(grep -R redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+        then
+        echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
+    elif [ -f /etc/php/7.2/fpm/php.ini ]
+    then
+            if ! [ "$(grep -R redis.so /etc/php/7.2/fpm/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+            then
+                echo "extension=redis.so" >> /etc/php/7.2/fpm/php.ini
+    elif [ -f /etc/php/7.0/apache2/php.ini ]
+    then
+                if ! [ "$(grep -R redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+                then
+                    echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
+                fi
+            fi
+        fi
+    fi
     restart_webserver
 elif pecl list | grep redis >/dev/null 2>&1
 then
@@ -90,29 +111,30 @@ then
     pecl channel-update pecl.php.net
     yes no | pecl upgrade redis
     service redis-server restart
-    restart_webserver
-fi
-
-# Check if redis.so is enabled
-if [ -f /etc/php/7.2/apache2/php.ini ]
-then
-    if ! [ "$(grep -R redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+        # Check if redis.so is enabled
+    if [ -f /etc/php/7.2/apache2/php.ini ]
     then
-    echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
-elif [ -f /etc/php/7.2/fpm/php.ini ]
-then
-        if ! [ "$(grep -R redis.so /etc/php/7.2/fpm/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+        if ! [ "$(grep -R redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
         then
-            echo "extension=redis.so" >> /etc/php/7.2/fpm/php.ini
-elif [ -f /etc/php/7.0/apache2/php.ini ]
-then
-            if ! [ "$(grep -R redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+        echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
+    elif [ -f /etc/php/7.2/fpm/php.ini ]
+    then
+            if ! [ "$(grep -R redis.so /etc/php/7.2/fpm/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
             then
-                echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
+                echo "extension=redis.so" >> /etc/php/7.2/fpm/php.ini
+    elif [ -f /etc/php/7.0/apache2/php.ini ]
+    then
+                if ! [ "$(grep -R redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ] > /dev/null 2>&1
+                then
+                    echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
+                fi
             fi
         fi
     fi
+    restart_webserver
 fi
+
+
 
 # Update adminer
 if [ -d $ADMINERDIR ]

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -90,7 +90,7 @@ then
     # PHP 7.2 fpm
     elif [ -f "$PHP_INI" ]
     then
-        ! [[ "$(grep -R extension=redis.so $PHP_INI)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> "$PHP_INI"
+        ! [[ "$(grep -R extension=redis.so "$PHP_INI")" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> "$PHP_INI"
     fi
     restart_webserver
 elif pecl list | grep redis >/dev/null 2>&1

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -84,7 +84,7 @@ then
     then
         ! [[ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
     # PHP 7.2 apache
-    elif [ -f /etc/php/7.0/apache2/php.ini ]
+    elif [ -f /etc/php/7.2/apache2/php.ini ]
     then
         ! [[ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
     # PHP 7.2 fpm

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -110,7 +110,7 @@ then
     then
         ! [[ "$(grep -R extension=redis.so /etc/php/7.0/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.0/apache2/php.ini
     # PHP 7.2 apache
-    elif [ -f /etc/php/7.0/apache2/php.ini ]
+    elif [ -f /etc/php/7.2/apache2/php.ini ]
     then
         ! [[ "$(grep -R extension=redis.so /etc/php/7.2/apache2/php.ini)" == "extension=redis.so" ]]  > /dev/null 2>&1 && echo "extension=redis.so" >> /etc/php/7.2/apache2/php.ini
     # PHP 7.2 fpm


### PR DESCRIPTION
This is needed as in older versions of the VM redis.so wasn't added. This adds redis.so in the correct place if:
- the php.ini file exist
- if it's not already added (if not it adds it)
- if pecl is used (which it is since we update to it)

It it's compatible with:
- php7.0 apache
- php7.2 apache
- php7.2 fpm ($PHP_INI)


 cc @nextcloud/vm for feedback