### PR TITLE
Fixed issue where HTTP to HTTPS redirect leaves out the / and ultimately fails to work correctly

### DIFF
--- a/lets-encrypt/activate-ssl.sh
+++ b/lets-encrypt/activate-ssl.sh
@@ -117,7 +117,7 @@ then
     cat << SSL_CREATE > "$ssl_conf"
 <VirtualHost *:80>
     ServerName $domain
-    Redirect / https://$domain
+    Redirect / https://$domain/
 </VirtualHost>
 
 <VirtualHost *:443>


### PR DESCRIPTION
Currently, when redirecting from HTTP to HTTPS, it fails if there is anything after $domain because it does not add back the `/`. 
Example: `http://example.com/apps/files/` redirects to `http://example.comapps/files/`
This is wrong!

I fixed it by adding the `/` on line 120.

Thanks for your time and consideration and have a great day!