### PR TITLE
Remove IP version preference code

### DIFF
--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -2,9 +2,6 @@
 
 # T&M Hansson IT AB © - 2020, https://www.hanssonit.se/
 
-# Prefer IPv4
-sed -i "s|#precedence ::ffff:0:0/96  100|precedence ::ffff:0:0/96  100|g" /etc/gai.conf
-
 # Install curl if not existing
 if [ "$(dpkg-query -W -f='${Status}' "curl" 2>/dev/null | grep -c "ok installed")" == "1" ]
 then


### PR DESCRIPTION
There is no discernible and good reason that the user's system IP version preference should be modified from the default and especially not without notifying the user that such a drastic change was made to their system.

In addition, if this was added to solve some sort of networking issue with the user's system, that is outside the scope of a script like this.