### PR TITLE
check if the apps got installed in the onlyoffice script

### DIFF
--- a/apps/onlyoffice.sh
+++ b/apps/onlyoffice.sh
@@ -157,5 +157,10 @@ then
     msg_box "OnlyOffice was successfully installed."
 fi
 
+if ! is_app_installed onlyoffice || ! is_app_installed documentserver_community
+then
+    msg_box "Something got wrong during the installation. Please report this here: $ISSUES"
+fi
+
 # Just make sure the script exits
 exit


### PR DESCRIPTION
I recently upgraded to NC 18 and have run the onlyoffice script again. strangely the onlyoffice app wasn't installed after changing to the hub method of onlyoffice. So I think the check is worth it to track this.