### PR TITLE
Accept 90% of demanded RAM as sufficient

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -622,10 +622,12 @@ fi
 # Example: ram_check 2 Nextcloud
 ram_check() {
 mem_available="$(awk '/MemTotal/{print $2}' /proc/meminfo)"
-if [ "${mem_available}" -lt "$((${1}*1002400))" ]
+mem_available_gb="$(echo "scale=2; $mem_available/(1024*1024)" | bc)"
+mem_required="$((${1}*(924*1024)))" # 100MiB/GiB margin less is also ok
+if [ "${mem_available}" -lt "${mem_required}" ]
 then
     print_text_in_color "$IRed" "Error: ${1} GB RAM required to install ${2}!" >&2
-    print_text_in_color "$IRed" "Current RAM is: ("$((mem_available/1002400))" GB)" >&2
+    print_text_in_color "$IRed" "Current RAM is: ("$mem_available_gb" GB)" >&2
     sleep 3
     msg_box "If you want to bypass this check you could do so by commenting out (# before the line) 'ram_check X' in the script that you are trying to run.
 
@@ -634,7 +636,7 @@ then
     Please notice that things may be veery slow and not work as expeced. YOU HAVE BEEN WARNED!"
     exit 1
 else
-    print_text_in_color "$IGreen" "RAM for ${2} OK! ($((mem_available/1002400)) GB)"
+    print_text_in_color "$IGreen" "RAM for ${2} OK! ("$mem_available_gb" GB)"
 fi
 }
 

--- a/lib.sh
+++ b/lib.sh
@@ -624,7 +624,7 @@ ram_check() {
 install_if_not bc
 mem_available="$(awk '/MemTotal/{print $2}' /proc/meminfo)"
 mem_available_gb="$(echo "scale=2; $mem_available/(1024*1024)" | bc)"
-mem_required="$((${1}*(1000*1024)))" # 100MiB/GiB margin
+mem_required="$((${1}*(924*1024)))" # 100MiB/GiB margin and allow 90% to be able to run on physical machines
 if [ "${mem_available}" -lt "${mem_required}" ]
 then
     print_text_in_color "$IRed" "Error: ${1} GB RAM required to install ${2}!" >&2

--- a/lib.sh
+++ b/lib.sh
@@ -628,7 +628,7 @@ mem_required="$((${1}*(1000*1024)))" # 100MiB/GiB margin
 if [ "${mem_available}" -lt "${mem_required}" ]
 then
     print_text_in_color "$IRed" "Error: ${1} GB RAM required to install ${2}!" >&2
-    print_text_in_color "$IRed" "Current RAM is: ("$mem_available_gb" GB)" >&2
+    print_text_in_color "$IRed" "Current RAM is: ($mem_available_gb GB)" >&2
     sleep 3
     msg_box "If you want to bypass this check you could do so by commenting out (# before the line) 'ram_check X' in the script that you are trying to run.
 
@@ -637,7 +637,7 @@ then
     Please notice that things may be veery slow and not work as expeced. YOU HAVE BEEN WARNED!"
     exit 1
 else
-    print_text_in_color "$IGreen" "RAM for ${2} OK! ("$mem_available_gb" GB)"
+    print_text_in_color "$IGreen" "RAM for ${2} OK! ($mem_available_gb GB)"
 fi
 }
 

--- a/lib.sh
+++ b/lib.sh
@@ -621,9 +621,10 @@ fi
 # Call it like this: ram_check [amount of min RAM in GB] [for which program]
 # Example: ram_check 2 Nextcloud
 ram_check() {
+install_if_not bc
 mem_available="$(awk '/MemTotal/{print $2}' /proc/meminfo)"
 mem_available_gb="$(echo "scale=2; $mem_available/(1024*1024)" | bc)"
-mem_required="$((${1}*(924*1024)))" # 100MiB/GiB margin less is also ok
+mem_required="$((${1}*(1000*1024)))" # 100MiB/GiB margin
 if [ "${mem_available}" -lt "${mem_required}" ]
 then
     print_text_in_color "$IRed" "Error: ${1} GB RAM required to install ${2}!" >&2


### PR DESCRIPTION
Usually not all RAM is available/listed in /proc/meminfo so a 2GB/8GB/whatever device usually has up to 10% less. The proposed change enables all devices labelled/marketed as a certain amount of GB to actually pass the test for this amount of GB. Otherwise none of my two tested devices pass the test for the amount of RAM that they are supposed to  have.

https://github.com/nextcloud/vm/issues/1157