### PR TITLE
Can elasticsearch container be bound only to localhost?

### DIFF
--- a/apps/fulltextsearch.sh
+++ b/apps/fulltextsearch.sh
@@ -145,8 +145,8 @@ docker run -d --restart always \
 --name $fts_es_name \
 --ulimit memlock=-1:-1 \
 --ulimit nofile=65536:65536 \
--p 9200:9200 \
--p 9300:9300 \
+-p 127.0.0.1:9200:9200 \
+-p 127.0.0.1:9300:9300 \
 -v esdata:/usr/share/elasticsearch/data \
 -v /opt/es/readonlyrest.yml:/usr/share/elasticsearch/config/readonlyrest.yml \
 -e "discovery.type=single-node" \


### PR DESCRIPTION
Is there any reason this container should expose ports to external network by default? 

I have seen that it's got the readonlyrest authenticating layer on it so I know it's not just "wide open", but it seems unnecessary from a security standpoint for it to be listening on 0.0.0.0 by default in this context?