### PR TITLE
Update fail2ban.sh

### DIFF
--- a/apps/fail2ban.sh
+++ b/apps/fail2ban.sh
@@ -115,9 +115,6 @@ failregex=^{"reqId":".*","remoteAddr":".*","app":"core","message":"Login failed:
             ^.*\"remoteAddr\":\"<HOST>\".*Trusted domain error.*\$
 NCONF
 
-# Disable default Debian sshd chain
-check_command sed -i "s|true|false|g" /etc/fail2ban/jail.d/defaults-debian.conf
-
 # Create jail.local file
 cat << FCONF > /etc/fail2ban/jail.local
 # The DEFAULT allows a global definition of the options. They can be overridden


### PR DESCRIPTION
minor grammatical and typo fixes, messages adjusted for clarity (average user probably does not care or would not be surprised about settings being erased after asking for uninstall and they can't do anything about it by the time the message is displayed if they wanted to keep the config)

Moved erasure of locally generated files before purge of package to remove warning about not-empty directory (and allow the directories to be deleted)

Add check/deletion in case $VMLOGS exists as a file instead of a directory (as was the case on my system) otherwise attempt to mkdir won't work and this while loop goes around forever (What problem does the loop solve? should there be a max number of attempts if retries are regularly required?)

Edit generated jail.local - 
bantime increased to 14 days
ssh:
debian/ubuntu package jail.conf includes a jail called sshd already, just enable that and set maxretry, this also means we can avoid the crude sed of all "true" to "false" in debian-default as we won't get two jails even if we keep our enabled=true (not strictly necessary but maybe desired just in case upstream default changes) because all instances are called sshd 
nextcloud:
logpath was pointed at directory, not the log file earlier configured by the script