### PR TITLE
possible fix for missing second disk import (zfs)

### DIFF
--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -142,9 +142,6 @@ unset NCDB
 DEBUG=0
 debug_mode
 
-# Nextcloud 18 is required.
-lowest_compatible_nc 18
-
 # Check that this run on the PostgreSQL VM
 if ! is_this_installed postgresql-common
 then
@@ -172,6 +169,9 @@ fi
 
 # Set locales
 run_static_script locales
+
+# Nextcloud 18 is required
+lowest_compatible_nc 18
 
 # Is this run as a pure root user?
 if is_root

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -142,8 +142,8 @@ unset NCDB
 DEBUG=0
 debug_mode
 
-# Nextcloud 16 is required.
-lowest_compatible_nc 16
+# Nextcloud 18 is required.
+lowest_compatible_nc 18
 
 # Check that this run on the PostgreSQL VM
 if ! is_this_installed postgresql-common

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -166,6 +166,9 @@ case "$choice" in
 esac
 fi
 
+# Change to zfs-mount-generator
+run_static_script change-to-zfs-mount-generator
+
 # Set DNS resolver
 # https://medium.com/@ahmadb/fixing-dns-issues-in-ubuntu-18-04-lts-bd4f9ca56620
 choice=$(whiptail --title "Set DNS Resolver" --radiolist "Which DNS provider should this Nextcloud box use?\nSelect by pressing the spacebar and ENTER" "$WT_HEIGHT" "$WT_WIDTH" 4 \

--- a/static/change-to-zfs-mount-generator.sh
+++ b/static/change-to-zfs-mount-generator.sh
@@ -82,5 +82,5 @@ sleep 1
 if [ -s /etc/zfs/zfs-list.cache/"$POOLNAME" ]
 then
     print_text_in_color "$ICyan" "/etc/zfs/zfs-list.cache/$POOLNAME is emtpy, setting values manually instead."
-    echo "$(zfs list -H -o name,mountpoint,canmount,atime,relatime,devices,exec,readonly,setuid,nbmand,encroot,keylocation)" > /etc/zfs/zfs-list.cache/"$POOLNAME"
+    zfs list -H -o name,mountpoint,canmount,atime,relatime,devices,exec,readonly,setuid,nbmand,encroot,keylocation > /etc/zfs/zfs-list.cache/"$POOLNAME"
 fi


### PR DESCRIPTION
zpool.cache have a tendency to fail. This PR aims to make it more robust so that users don't manually have to import the zpool with `zpool import` just to get up and running in case the pool failed to import during boot.

New script https://github.com/nextcloud/vm/blob/master/static/change-to-zfs-mount-generator.sh