### PR TITLE
update the way scripts are run and downloaded

### DIFF
--- a/apps/additional_apps.sh
+++ b/apps/additional_apps.sh
@@ -34,42 +34,42 @@ case "$choice" in
     *"Fail2ban"*)
         clear
         print_text_in_color "$ICyan" "Downloading Fail2ban.sh..."
-        run_script App fail2ban
+        run_script APP fail2ban
     ;;&
     *"Adminer"*)
         clear
         print_text_in_color "$ICyan" "Downloading Adminer.sh..."
-        run_script App adminer
+        run_script APP adminer
     ;;&
     *"Netdata"*)
         clear
         print_text_in_color "$ICyan" "Downloading Netdata.sh..."
-        run_script App netdata
+        run_script APP netdata
     ;;&
     *"OnlyOffice"*)
         clear
         print_text_in_color "$ICyan" "Downloading OnlyOffice.sh..."
-        run_script App onlyoffice
+        run_script APP onlyoffice
     ;;&
     *"Collabora"*)
         clear
         print_text_in_color "$ICyan" "Downloading Collabora.sh..."
-        run_script App collabora
+        run_script APP collabora
     ;;&
     *"Bitwarden"*)
         clear
         print_text_in_color "$ICyan" "Downloading Bitwarden.sh..."
-        run_script App tmbitwarden
+        run_script APP tmbitwarden
     ;;&
     *"FullTextSearch"*)
         clear
         print_text_in_color "$ICyan" "Downloading FullTextSearch.sh..."
-        run_script App fulltextsearch
+        run_script APP fulltextsearch
     ;;&
     *"PreviewGenerator"*)
         clear
         print_text_in_color "$ICyan" "Downloading PreviewGenerator.sh..."
-        run_script App previewgenerator
+        run_script APP previewgenerator
     ;;&
     *"LDAP"*)
         clear
@@ -84,12 +84,12 @@ case "$choice" in
     *"Talk"*)
         clear
         print_text_in_color "$ICyan" "Downloading Talk.sh..."
-        run_script App talk
+        run_script APP talk
     ;;&
     *"SMB-mount"*)
         clear
         print_text_in_color "$ICyan" "Downloading SMB-mount.sh..."
-        run_script App smbmount
+        run_script APP smbmount
     ;;&
     *)
     ;;

--- a/apps/additional_apps.sh
+++ b/apps/additional_apps.sh
@@ -34,42 +34,42 @@ case "$choice" in
     *"Fail2ban"*)
         clear
         print_text_in_color "$ICyan" "Downloading Fail2ban.sh..."
-        run_app_script fail2ban
+        run_script App fail2ban
     ;;&
     *"Adminer"*)
         clear
         print_text_in_color "$ICyan" "Downloading Adminer.sh..."
-        run_app_script adminer
+        run_script App adminer
     ;;&
     *"Netdata"*)
         clear
         print_text_in_color "$ICyan" "Downloading Netdata.sh..."
-        run_app_script netdata
+        run_script App netdata
     ;;&
     *"OnlyOffice"*)
         clear
         print_text_in_color "$ICyan" "Downloading OnlyOffice.sh..."
-        run_app_script onlyoffice
+        run_script App onlyoffice
     ;;&
     *"Collabora"*)
         clear
         print_text_in_color "$ICyan" "Downloading Collabora.sh..."
-        run_app_script collabora
+        run_script App collabora
     ;;&
     *"Bitwarden"*)
         clear
         print_text_in_color "$ICyan" "Downloading Bitwarden.sh..."
-        run_app_script tmbitwarden
+        run_script App tmbitwarden
     ;;&
     *"FullTextSearch"*)
         clear
         print_text_in_color "$ICyan" "Downloading FullTextSearch.sh..."
-        run_app_script fulltextsearch
+        run_script App fulltextsearch
     ;;&
     *"PreviewGenerator"*)
         clear
         print_text_in_color "$ICyan" "Downloading PreviewGenerator.sh..."
-        run_app_script previewgenerator
+        run_script App previewgenerator
     ;;&
     *"LDAP"*)
         clear
@@ -84,12 +84,12 @@ case "$choice" in
     *"Talk"*)
         clear
         print_text_in_color "$ICyan" "Downloading Talk.sh..."
-        run_app_script talk
+        run_script App talk
     ;;&
     *"SMB-mount"*)
         clear
         print_text_in_color "$ICyan" "Downloading SMB-mount.sh..."
-        run_app_script smbmount
+        run_script App smbmount
     ;;&
     *)
     ;;

--- a/lets-encrypt/activate-tls.sh
+++ b/lets-encrypt/activate-tls.sh
@@ -89,7 +89,7 @@ check_open_port 80 "$TLSDOMAIN"
 check_open_port 443 "$TLSDOMAIN"
 
 # Fetch latest version of test-new-config.sh
-check_command download_le_script test-new-config
+check_command download_script LETS_ENC test-new-config
 
 # Install certbot (Let's Encrypt)
 install_certbot

--- a/lets-encrypt/test-new-config.sh
+++ b/lets-encrypt/test-new-config.sh
@@ -47,7 +47,7 @@ then
 fi
 
 # Set trusted domains
-run_static_script trusted
+run_script STATIC trusted
 
 add_crontab_le() {
 # shellcheck disable=SC2016

--- a/lib.sh
+++ b/lib.sh
@@ -845,7 +845,7 @@ download_script() {
 
 # call like: run_script folder_variable name_of_script
 # e.g. run_script APP additional_apps
-# Use it for functions like run_static_script
+# Use it for functions like run_script STATIC
 run_script() {
     rm -f "${SCRIPTS}/${2}.sh" "${SCRIPTS}/${2}.php" "${SCRIPTS}/${2}.py"
     if download_script "${1}" "${2}"

--- a/lib.sh
+++ b/lib.sh
@@ -284,7 +284,7 @@ fi
 # Warn user that HTTP/2 will be disabled if installing app that use Apache2 PHP instead of PHP-FPM
 # E.g: http2_warn Modsecurity
 http2_warn() {
-msg_box "This VM has HTTP/2 enabled by default. 
+msg_box "This VM has HTTP/2 enabled by default.
 
 If you continue with installing $1, HTTP/2 will be disabled since it's not compatible with the mpm module used by $1.
 
@@ -569,13 +569,13 @@ if lsb_release -sc | grep -ic "bionic" &> /dev/null || lsb_release -sc | grep -i
 then
     OS=1
 elif lsb_release -i | grep -ic "Ubuntu" &> /dev/null
-then 
+then
     OS=1
 elif uname -a | grep -ic "bionic" &> /dev/null || uname -a | grep -ic "focal" &> /dev/null
 then
     OS=1
 elif uname -v | grep -ic "Ubuntu" &> /dev/null
-then 
+then
     OS=1
 fi
 
@@ -965,7 +965,7 @@ or experience other issues then please report this to $ISSUES"
 #    rm master.zip*
 #    rm updater/ -R
 #    mv updater-master/ updater/
-#    download_static_script setup_secure_permissions_nextcloud -P $SCRIPTS
+#    download_script STATIC setup_secure_permissions_nextcloud -P $SCRIPTS
 #    bash $SECURE
 #    cd
 
@@ -973,7 +973,7 @@ or experience other issues then please report this to $ISSUES"
     chown -R www-data:www-data "$NCPATH"
     rm -rf "$NCPATH"/assets
     yes | sudo -u www-data php /var/www/nextcloud/updater/updater.phar
-    download_static_script setup_secure_permissions_nextcloud -P $SCRIPTS
+    download_script STATIC setup_secure_permissions_nextcloud -P $SCRIPTS
     bash $SECURE
     occ_command maintenance:mode --off
 fi
@@ -990,9 +990,9 @@ if [ "${CURRENTVERSION%%.*}" -ge "$1" ]
 then
     sleep 1
 else
-msg_box "Your current version are still not compatible with the version required to run this script. 
+msg_box "Your current version are still not compatible with the version required to run this script.
 
-To upgrade between major versions, please check this out: 
+To upgrade between major versions, please check this out:
 https://shop.hanssonit.se/product/upgrade-between-major-owncloud-nextcloud-versions/"
     occ_command -V
     exit

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -192,7 +192,7 @@ Please create a user with sudo permissions and the run this command:
 sudo -u [user-with-sudo-permissions] sudo bash /var/scripts/nextcloud-startup-script.sh
 
 We will do this for you when you hit OK."
-       download_static_script adduser
+       download_script STATIC adduser
        bash $SCRIPTS/adduser.sh "$SCRIPTS/nextcloud-startup-script.sh"
        rm $SCRIPTS/adduser.sh
        else
@@ -236,26 +236,26 @@ echo
 print_text_in_color "$ICyan" "Getting scripts from GitHub to be able to run the first setup..."
 # Scripts in static (.sh, .php, .py)
 download_le_script activate-tls
-download_static_script temporary-fix
-download_static_script update
-download_static_script trusted
-download_static_script test_connection
-download_static_script setup_secure_permissions_nextcloud
-download_static_script change_db_pass
-download_static_script nextcloud
-download_static_script update-config
-download_static_script menu
-download_static_script server_configuration
-download_static_script nextcloud_configuration
+download_script STATIC temporary-fix
+download_script STATIC update
+download_script STATIC trusted
+download_script STATIC test_connection
+download_script STATIC setup_secure_permissions_nextcloud
+download_script STATIC change_db_pass
+download_script STATIC nextcloud
+download_script STATIC update-config
+download_script STATIC menu
+download_script STATIC server_configuration
+download_script STATIC nextcloud_configuration
 download_app_script additional_apps
 
 if home_sme_server
 then
-    download_static_script nhss_index
+    download_script STATIC nhss_index
     mv $SCRIPTS/nhss_index.php $HTML/index.php && rm -f $HTML/html/index.html
     chmod 750 $HTML/index.php && chown www-data:www-data $HTML/index.php
 else
-    download_static_script index
+    download_script STATIC index
     mv $SCRIPTS/index.php $HTML/index.php && rm -f $HTML/html/index.html
     chmod 750 $HTML/index.php && chown www-data:www-data $HTML/index.php
 fi

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -236,7 +236,6 @@ echo
 print_text_in_color "$ICyan" "Getting scripts from GitHub to be able to run the first setup..."
 # Scripts in static (.sh, .php, .py)
 download_le_script activate-tls
-download_static_script update-config
 download_static_script temporary-fix
 download_static_script update
 download_static_script trusted
@@ -244,6 +243,7 @@ download_static_script test_connection
 download_static_script setup_secure_permissions_nextcloud
 download_static_script change_db_pass
 download_static_script nextcloud
+download_static_script update-config
 download_static_script menu
 download_static_script server_configuration
 download_static_script nextcloud_configuration

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -235,7 +235,7 @@ touch "$SCRIPTS/you-can-not-run-the-startup-script-several-times"
 echo
 print_text_in_color "$ICyan" "Getting scripts from GitHub to be able to run the first setup..."
 # Scripts in static (.sh, .php, .py)
-download_le_script activate-tls
+download_script LETS_ENC activate-tls
 download_script STATIC temporary-fix
 download_script STATIC update
 download_script STATIC trusted
@@ -247,7 +247,7 @@ download_script STATIC update-config
 download_script STATIC menu
 download_script STATIC server_configuration
 download_script STATIC nextcloud_configuration
-download_app_script additional_apps
+download_script APP additional_apps
 
 if home_sme_server
 then

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -515,7 +515,7 @@ apt autoclean
 
 # Set trusted domain in config.php
 bash $SCRIPTS/trusted.sh
-rm  -f $SCRIPTS/update.sh
+rm  -f $SCRIPTS/trusted.sh
 
 # Success!
 msg_box "Congratulations! You have successfully installed Nextcloud!

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -235,19 +235,19 @@ touch "$SCRIPTS/you-can-not-run-the-startup-script-several-times"
 echo
 print_text_in_color "$ICyan" "Getting scripts from GitHub to be able to run the first setup..."
 # Scripts in static (.sh, .php, .py)
-download_script LETS_ENC activate-tls
-download_script STATIC update-config
-download_script STATIC temporary-fix
-download_script STATIC update
-download_script STATIC trusted
-download_script STATIC test_connection
-download_script STATIC setup_secure_permissions_nextcloud
-download_script STATIC change_db_pass
-download_script STATIC nextcloud
-download_script STATIC menu
-download_script STATIC server_configuration
-download_script STATIC nextcloud_configuration
-download_script APP additional_apps
+download_le_script activate-tls
+download_static_script update-config
+download_static_script temporary-fix
+download_static_script update
+download_static_script trusted
+download_static_script test_connection
+download_static_script setup_secure_permissions_nextcloud
+download_static_script change_db_pass
+download_static_script nextcloud
+download_static_script menu
+download_static_script server_configuration
+download_static_script nextcloud_configuration
+download_app_script additional_apps
 
 if home_sme_server
 then

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -171,7 +171,7 @@ then
 fi
 
 # Set locales
-run_static_script locales
+run_script STATIC locales
 
 # Nextcloud 18 is required
 lowest_compatible_nc 18
@@ -209,7 +209,7 @@ please abort this script (CTRL+C) and report this issue to $ISSUES."
 fi
 
 # Upgrade mirrors
-run_static_script locate_mirror
+run_script STATIC locate_mirror
 
 ######## The first setup is OK to run to this point several times, but not any further ########
 if [ -f "$SCRIPTS/you-can-not-run-the-startup-script-several-times" ]

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -515,7 +515,7 @@ apt autoclean
 
 # Set trusted domain in config.php
 bash $SCRIPTS/trusted.sh
-rm  -f $SCRIPTS/trusted.sh
+rm -f $SCRIPTS/trusted.sh
 
 # Success!
 msg_box "Congratulations! You have successfully installed Nextcloud!

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -235,18 +235,20 @@ touch "$SCRIPTS/you-can-not-run-the-startup-script-several-times"
 echo
 print_text_in_color "$ICyan" "Getting scripts from GitHub to be able to run the first setup..."
 # Scripts in static (.sh, .php, .py)
-download_static_script temporary-fix
-download_static_script update
-download_static_script trusted
-download_static_script test_connection
-download_static_script setup_secure_permissions_nextcloud
-download_static_script change_db_pass
-download_static_script nextcloud
-download_static_script update-config
-download_static_script apps
-download_static_script configuration
-download_le_script activate-tls
-download_static_script menu
+download_script LETS_ENC activate-tls
+download_script STATIC update-config
+download_script STATIC temporary-fix
+download_script STATIC update
+download_script STATIC trusted
+download_script STATIC test_connection
+download_script STATIC setup_secure_permissions_nextcloud
+download_script STATIC change_db_pass
+download_script STATIC nextcloud
+download_script STATIC menu
+download_script STATIC server_configuration
+download_script STATIC nextcloud_configuration
+download_script APP additional_apps
+
 if home_sme_server
 then
     download_static_script nhss_index
@@ -364,10 +366,10 @@ clear
 bash $SCRIPTS/server_configuration.sh
 
 # Nextcloud configuration
-bash $SCRIPTS/configuration.sh
+bash $SCRIPTS/nextcloud_configuration.sh
 
 # Install apps
-bash $SCRIPTS/apps.sh
+bash $SCRIPTS/additional_apps.sh
 
 # Change passwords
 # CLI USER
@@ -458,9 +460,9 @@ rm -f "$SCRIPTS/instruction.sh"
 rm -f "$NCDATA/nextcloud.log"
 rm -f "$SCRIPTS/static_ip.sh"
 rm -f "$SCRIPTS/lib.sh"
-rm -f "$SCRIPTS/configuration.sh"
-rm -f "$SCRIPTS/apps.sh"
 rm -f "$SCRIPTS/server_configuration.sh"
+rm -f "$SCRIPTS/nextcloud_configuration.sh"
+rm -f "$SCRIPTS/additional_apps.sh"
 
 find /root "/home/$UNIXUSER" -type f \( -name '*.sh*' -o -name '*.html*' -o -name '*.tar*' -o -name 'results' -o -name '*.zip*' \) -delete
 find "$NCPATH" -type f \( -name 'results' -o -name '*.sh*' \) -delete
@@ -512,13 +514,8 @@ apt autoremove -y
 apt autoclean
 
 # Set trusted domain in config.php
-if [ -f "$SCRIPTS"/trusted.sh ]
-then
-    bash "$SCRIPTS"/trusted.sh
-    rm -f "$SCRIPTS"/trusted.sh
-else
-    run_static_script trusted
-fi
+bash $SCRIPTS/trusted.sh
+rm  -f $SCRIPTS/update.sh
 
 # Success!
 msg_box "Congratulations! You have successfully installed Nextcloud!

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -66,7 +66,7 @@ debug_mode
 root_check
 
 # Set locales
-run_static_script locales
+run_script STATIC locales
 
 # Test RAM size (2GB min) + CPUs (min 1)
 ram_check 2 Nextcloud
@@ -137,7 +137,7 @@ install_if_not build-essential
 # Just check if the function works and run disk setup
 if home_sme_server
 then
-    run_static_script format-sda-nuc-server
+    run_script STATIC format-sda-nuc-server
 else
 # Set dual or single drive setup
 msg_box "This VM is designed to run with two disks, one for OS and one for DATA. This will get you the best performance since the second disk is using ZFS which is a superior filesystem.
@@ -152,15 +152,15 @@ choice=$(whiptail --title "Choose disk format" --radiolist "How would you like t
 
 case "$choice" in
     "2 Disks Auto")
-        run_static_script format-sdb
+        run_script STATIC format-sdb
         # Change to zfs-mount-generator
-        run_static_script change-to-zfs-mount-generator
+        run_script STATIC change-to-zfs-mount-generator
 
     ;;
     "2 Disks Manual")
-        run_static_script format-chosen
+        run_script STATIC format-chosen
         # Change to zfs-mount-generator
-        run_static_script change-to-zfs-mount-generator
+        run_script STATIC change-to-zfs-mount-generator
     ;;
     "1 Disk")
         print_text_in_color "$IRed" "1 Disk setup chosen."
@@ -198,7 +198,7 @@ test_connection
 network_ok
 
 # Check current repo
-run_static_script locate_mirror
+run_script STATIC locate_mirror
 
 # Install PostgreSQL
 # sudo add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main"
@@ -435,7 +435,7 @@ echo "pgsql.log_notice = 0"
 } >> "$PHP_FPM_DIR"/conf.d/20-pdo_pgsql.ini
 
 # Install Redis (distrubuted cache)
-run_static_script redis-server-ubuntu
+run_script STATIC redis-server-ubuntu
 
  # Install smbclient
  # php"$PHPVER"-smbclient does not yet work in PHP 7.4
@@ -718,8 +718,8 @@ chmod +x -R "$SCRIPTS"
 chown root:root -R "$SCRIPTS"
 
 # Prepare first bootup
-check_command run_static_script change-ncadmin-profile
-check_command run_static_script change-root-profile
+check_command run_script STATIC change-ncadmin-profile
+check_command run_script STATIC change-root-profile
 
 # Upgrade
 apt update -q4 & spinner_loading

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -73,7 +73,7 @@ ram_check 2 Nextcloud
 cpu_check 1 Nextcloud
 
 # Create new current user
-download_static_script adduser
+download_script STATIC adduser
 bash $SCRIPTS/adduser.sh "nextcloud_install_production.sh"
 rm -f $SCRIPTS/adduser.sh
 
@@ -333,7 +333,7 @@ tar -xjf "$HTML/$STABLEVERSION.tar.bz2" -C "$HTML" & spinner_loading
 rm "$HTML/$STABLEVERSION.tar.bz2"
 
 # Secure permissions
-download_static_script setup_secure_permissions_nextcloud
+download_script STATIC setup_secure_permissions_nextcloud
 bash $SECURE & spinner_loading
 
 # Install Nextcloud
@@ -359,7 +359,7 @@ crontab -u www-data -l | { cat; echo "*/5  *  *  *  * php -f $NCPATH/cron.php > 
 # Run the updatenotification on a schelude
 occ_command config:system:set upgrade.disable-web --value="true"
 print_text_in_color "$ICyan" "Configuring update notifications specific for this server..."
-download_static_script updatenotification
+download_script STATIC updatenotification
 check_command chmod +x "$SCRIPTS"/updatenotification.sh
 crontab -u root -l | { cat; echo "59 $AUT_UPDATES_TIME * * * $SCRIPTS/updatenotification.sh > /dev/null 2>&1"; } | crontab -u root -
 
@@ -703,9 +703,9 @@ esac
 # Get needed scripts for first bootup
 check_command curl_to_dir "$GITHUB_REPO" nextcloud-startup-script.sh "$SCRIPTS"
 check_command curl_to_dir "$GITHUB_REPO" lib.sh "$SCRIPTS"
-download_static_script instruction
-download_static_script history
-download_static_script static_ip
+download_script STATIC instruction
+download_script STATIC history
+download_script STATIC static_ip
 
 if home_sme_server
 then

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -694,7 +694,7 @@ case "$choice" in
         install_and_enable_app groupfolders
     ;;&
     *"Webmin"*)
-        run_app_script webmin
+        run_script App webmin
     ;;&
     *)
     ;;

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -399,9 +399,9 @@ occ_command config:system:set trashbin_retention_obligation --value="auto, 180"
 occ_command config:system:set versions_retention_obligation --value="auto, 365"
 
 # Remove simple signup
-occ_command config:system:set simpleSignUpLink.shown --value="false" 
+occ_command config:system:set simpleSignUpLink.shown --value="false"
 
-# Enable OPCache for PHP 
+# Enable OPCache for PHP
 # https://docs.nextcloud.com/server/14/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
 phpenmod opcache
 {
@@ -611,13 +611,13 @@ then
     # just in case if .htaccess gets disabled
     Require all denied
     </Directory>
-    
+
     # The following lines prevent .htaccess and .htpasswd files from being
     # viewed by Web clients.
     <Files ".ht*">
     Require all denied
     </Files>
-    
+
     # Disable HTTP TRACE method.
     TraceEnable off
 
@@ -694,7 +694,7 @@ case "$choice" in
         install_and_enable_app groupfolders
     ;;&
     *"Webmin"*)
-        run_script App webmin
+        run_script APP webmin
     ;;&
     *)
     ;;

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -74,11 +74,11 @@ then
     then
         print_text_in_color "$ICyan" "Changing to Overlay2 for Docker CE..."
         print_text_in_color "$ICyan" "Please report any issues to $ISSUES."
-        run_static_script docker_overlay2
+        run_script STATIC docker_overlay2
     elif grep -q "aufs" /etc/default/docker
     then
         apt-mark hold docker-ce
-        run_static_script docker_overlay2
+        run_script STATIC docker_overlay2
     fi
 fi
 
@@ -222,7 +222,7 @@ if is_this_installed libzfs2linux
 then
     if grep -rq ncdata /etc/mtab
     then
-        run_static_script prune_zfs_snaphots
+        run_script STATIC prune_zfs_snaphots
     fi
 fi
 
@@ -521,7 +521,7 @@ then
 fi
 
 # Recover apps that exists in the backed up apps folder
-run_static_script recover_apps
+run_script STATIC recover_apps
 
 # Remove header for Nextcloud 14 (already in .htaccess)
 if [ -f /etc/apache2/sites-available/"$(hostname -f)".conf ]

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -231,13 +231,13 @@ CURRUSR="$(getent group sudo | cut -d: -f4 | cut -d, -f1)"
 if grep -q "6.ifcfg.me" $SCRIPTS/nextcloud.sh &>/dev/null
 then
    rm -f "$SCRIPTS/nextcloud.sh"
-   download_static_script nextcloud
+   download_script STATIC nextcloud
    chown "$CURRUSR":"$CURRUSR" "$SCRIPTS/nextcloud.sh"
    chmod +x "$SCRIPTS/nextcloud.sh"
 elif [ -f $SCRIPTS/techandme.sh ]
 then
    rm -f "$SCRIPTS/techandme.sh"
-   download_static_script nextcloud
+   download_script STATIC nextcloud
    chown "$CURRUSR":"$CURRUSR" "$SCRIPTS/nextcloud.sh"
    chmod +x "$SCRIPTS/nextcloud.sh"
    if [ -f /home/"$CURRUSR"/.bash_profile ]
@@ -253,7 +253,7 @@ fi
 if [ ! -f "$SECURE" ]
 then
     mkdir -p "$SCRIPTS"
-    download_static_script setup_secure_permissions_nextcloud
+    download_script STATIC setup_secure_permissions_nextcloud
     chmod +x "$SECURE"
 fi
 

--- a/static/apps.sh
+++ b/static/apps.sh
@@ -22,7 +22,7 @@ print_text_in_color "$ICyan" "Running the additional apps script..."
 if network_ok
 then
     # Delete, download, run
-    run_app_script additional_apps
+    run_script App additional_apps
 fi
 
 exit

--- a/static/apps.sh
+++ b/static/apps.sh
@@ -22,7 +22,7 @@ print_text_in_color "$ICyan" "Running the additional apps script..."
 if network_ok
 then
     # Delete, download, run
-    run_script App additional_apps
+    run_script APP additional_apps
 fi
 
 exit

--- a/static/configuration.sh
+++ b/static/configuration.sh
@@ -22,7 +22,7 @@ print_text_in_color "$ICyan" "Running the nextcloud configuration script..."
 if network_ok
 then
     # Delete, download, run
-    run_static_script nextcloud_configuration
+    run_script STATIC nextcloud_configuration
 fi
 
 exit

--- a/static/main_menu.sh
+++ b/static/main_menu.sh
@@ -27,7 +27,7 @@ case "$choice" in
     "Additional Apps")
         if network_ok
         then
-            run_script STATIC apps
+            run_script APP additional_apps
         fi
     ;;
     "Nextcloud Configuration")

--- a/static/main_menu.sh
+++ b/static/main_menu.sh
@@ -49,7 +49,7 @@ case "$choice" in
         else
             if network_ok
             then
-                download_static_script update
+                download_script STATIC update
                 bash $SCRIPTS/update.sh
             fi
         fi

--- a/static/main_menu.sh
+++ b/static/main_menu.sh
@@ -27,19 +27,19 @@ case "$choice" in
     "Additional Apps")
         if network_ok
         then
-            run_static_script apps
+            run_script STATIC apps
         fi
     ;;
     "Nextcloud Configuration")
         if network_ok
         then
-            run_static_script nextcloud_configuration
+            run_script STATIC nextcloud_configuration
         fi
     ;;
     "Server Configuration")
         if network_ok
         then
-            run_static_script server_configuration
+            run_script STATIC server_configuration
         fi
     ;;
     "Update Nextcloud")

--- a/static/menu.sh
+++ b/static/menu.sh
@@ -22,7 +22,7 @@ print_text_in_color "$ICyan" "Running the main menu script..."
 if network_ok
 then
     # Delete, download, run
-    run_static_script main_menu
+    run_script STATIC main_menu
 fi
 
 exit

--- a/static/nextcloud_configuration.sh
+++ b/static/nextcloud_configuration.sh
@@ -26,7 +26,7 @@ choice=$(whiptail --title "Nextcloud Configuration" --checklist "Which settings 
 
 case "$choice" in
     *"CookieLifetime"*)
-        run_static_script cookielifetime
+        run_script STATIC cookielifetime
     ;;&
     *"Share-folder"*)
         clear

--- a/static/prune_zfs_snaphots.sh
+++ b/static/prune_zfs_snaphots.sh
@@ -37,10 +37,10 @@ The script will also delete everything in trashbin for all users to free up some
             if [ -f $SCRIPTS/zfs-prune-snapshots ]
             then
                 rm -f "$SCRIPTS"/zfs-prune-snapshots
-                download_static_script zfs-prune-snapshots
+                download_script STATIC zfs-prune-snapshots
             elif [ ! -f $SCRIPTS/zfs-prune-snapshots.sh ]
             then
-                download_static_script zfs-prune-snapshots
+                download_script STATIC zfs-prune-snapshots
             fi
             check_command chmod +x "$SCRIPTS"/zfs-prune-snapshots.sh
             # Prune!

--- a/static/server_configuration.sh
+++ b/static/server_configuration.sh
@@ -41,15 +41,15 @@ choice=$(whiptail --title "Server configurations" --checklist "Choose what you w
 case "$choice" in
     *"Security"*)
         clear
-        run_static_script security
+        run_script STATIC security
     ;;&
     *"Static IP"*)
         clear
-        run_static_script static_ip
+        run_script STATIC static_ip
     ;;&
     *"Automatic updates"*)
         clear
-        run_static_script automatic_updates
+        run_script STATIC automatic_updates
     ;;&
     *"Activate TLS"*)
         clear

--- a/static/server_configuration.sh
+++ b/static/server_configuration.sh
@@ -66,7 +66,7 @@ https://www.techandme.se/open-port-80-443/"
             then
                 bash $SCRIPTS/activate-tls.sh
             else
-                download_le_script activate-tls
+                download_script LETS_ENC activate-tls
                 bash $SCRIPTS/activate-tls.sh
             fi
         else
@@ -74,7 +74,7 @@ https://www.techandme.se/open-port-80-443/"
             print_text_in_color "$ICyan" "OK, but if you want to run it later, just type: sudo bash $SCRIPTS/activate-tls.sh"
             any_key "Press any key to continue..."
         fi
-        
+
         # Just make sure they are gone
         rm -f "$SCRIPTS/test-new-config.sh"
         rm -f "$SCRIPTS/activate-tls.sh"

--- a/static/trusted.sh
+++ b/static/trusted.sh
@@ -13,7 +13,7 @@ true
 DEBUG=0
 debug_mode
 
-download_static_script update-config
+download_script STATIC update-config
 if [ -f $SCRIPTS/update-config.php ]
 then
     # Change config.php

--- a/static/update.sh
+++ b/static/update.sh
@@ -30,6 +30,6 @@ then
 fi
 
 # Delete, download, run
-run_main_script nextcloud_update
+run_script GITHUB_REPO nextcloud_update
 
 exit


### PR DESCRIPTION
@szaimen The setup script is only used in the released versions, so we might as well change the function.

Also run the right scripts (no need to download the apps, configuration scripts again which apps.sh and configuration does).

This is just a start, let's change all of them in the same PR, just don't have time now.