### PR TITLE
update bitwarden to allow subdomains

### DIFF
--- a/apps/collabora.sh
+++ b/apps/collabora.sh
@@ -294,14 +294,8 @@ then
     chown -R www-data:www-data "$NC_APPS_PATH"
     occ_command config:system:set trusted_domains 3 --value="$SUBDOMAIN"
     # Add prune command
-    {
-    echo "#!/bin/bash"
-    echo "docker system prune -a --force"
-    echo "exit"
-    } > "$SCRIPTS/dockerprune.sh"
-    chmod a+x "$SCRIPTS/dockerprune.sh"
-    crontab -u root -l | { cat; echo "@weekly $SCRIPTS/dockerprune.sh"; } | crontab -u root -
-    print_text_in_color "$ICyan" "Docker automatic prune job added."
+    add_dockerprune
+    # Restart Docker
     systemctl restart docker.service
     docker restart code
     print_text_in_color "$IGreen" "Collabora is now successfully installed."

--- a/apps/talk.sh
+++ b/apps/talk.sh
@@ -82,7 +82,7 @@ sudo bash talk.sh"
 fi
 
 # Let the user choose port. TURN_PORT in msg_box is taken from lib.sh and later changed if user decides to.
-NONO_PORTS=(22 25 53 80 443 3306 5432 7983 8983 10000)
+NONO_PORTS=(22 25 53 80 443 3306 5178 5179 5432 7983 8983 10000)
 msg_box "The default port for Talk used in this script is port $TURN_PORT.
 You can read more about that port here: https://www.speedguide.net/port.php?port=$TURN_PORT
 

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -94,7 +94,8 @@ check_command ./bitwarden.sh install
 if grep ^url /root/bwdata/config.yml | grep -q https || grep ^url /root/bwdata/config.yml | grep -q localhost
 then
     message "It seems like you have entered some wrong settings. We will remove bitwarden now again so that you can start over again."
-    ./bitwarden stop && docker system prune -af
+    check_command ./bitwarden.sh install
+    docker system prune -af
     rm -rf /root/bwdata
     exit 1
 fi

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -41,8 +41,7 @@ print_text_in_color "$ICyan" "Installing Bitwarden password manager..."
 
 msg_box "Bitwarden is a password manager that is seperate from Nextcloud, though we provide this service because it's self hosted and secure.
 
-If you just want to run Bitwarden locally (not connecting your smartphone) then you can use 'localhost' as domain.
-If you on the other hand want to run this on a domain, then please create a DNS record and point it to this server.
+If you on the other hand want to run this on a subdomain, then please create a DNS record and point it to this server.
 In the process of setting up Bitwarden you will be asked to generate an TLS cert with Let's Enrypt so no need to get your own prior to this setup.
 
 The script is based on this documentation: https://help.bitwarden.com/article/install-on-premise/
@@ -51,8 +50,8 @@ It's a good idea to read that before you start this script.
 Please also report any issues regarding this script setup to $ISSUES"
 
 msg_box "The necessary preparations to run expose Bitwarden to the internet are:
-1. The HTTP proxy and HTTPS ports for Bitwarden are 8080 and 8443, please open those ports before running this script.
-2. Please create a DNS record and point that to this server.
+1. Please open port 443 and 80 and point to this server.
+2. Please create a DNS record for your subdomain and point that to this server.
 3. Raise the amount of RAM to this server to at least 3 GB."
 
 if [[ "no" == $(ask_yes_or_no "Have you made the necessary preparations?") ]]
@@ -61,9 +60,22 @@ msg_box "OK, please do the necessary preparations before you run this script and
 
 To run this script again, execute $SCRIPTS/menu.sh and choose Additional Apps --> Bitwarden"
     exit
-else
-    sleep 0.1
 fi
+
+msg_box "ATTENTION!
+
+You will see in the next step a setup which is provided by bitwarden.
+You have to make your choices based on the following instructions, 
+otherwise things can go wrong since we have no influence on those scripts.
+Best is if you take a picture of those instructions so that you remember them later on.
+And please don't worry: we will create a valid SSL certificate afterwards ourselves.
+
+1. Enter your subdomain like e.g. 'bitwarden.example.com'
+2. You will be asked if you want to use 'lets encrypt'; Please type in no: 'n'
+3. Enter your installation ID, which you must get on https://bitwarden.com/host
+4. Enter your installation key, which you will also get there
+5. You will be asked if you have a SSL certificate which you want to use; Please type in no: 'n'
+6. You will be asked if you want to generate a self-signed SSL certificate; Please type in no: 'n'"
 
 # Install Docker
 install_docker
@@ -78,22 +90,125 @@ cd /root
 curl_to_dir "https://raw.githubusercontent.com/bitwarden/core/master/scripts" "bitwarden.sh" "/root"
 chmod +x /root/bitwarden.sh
 check_command ./bitwarden.sh install
-sed -i "s|http_port.*|http_port: 8080|g" /root/bwdata/config.yml
-sed -i "s|https_port.*|https_port: 8443|g" /root/bwdata/config.yml
+sed -i "s|http_port.*|http_port: 5178|g" /root/bwdata/config.yml
+sed -i "s|https_port.*|https_port: 5179|g" /root/bwdata/config.yml
+# Get Subdomain from config.yml and change it to https
+SUBDOMAIN=$(grep ^url /root/bwdata/config.yml)
+SUBDOMAIN=${SUBDOMAIN##*url: http://}
+sed -i "s|^url: .*|url: https://$SUBDOMAIN|g" /root/bwdata/config.yml
+sed -i 's|http://|https://|g' /root/bwdata/env/global.override.env
 check_command ./bitwarden.sh rebuild
 check_command ./bitwarden.sh start
-if check_command ./bitwarden.sh updatedb
-then
-msg_box "Bitwarden was sucessfully installed! Please visit $(grep 'url:' /root/bwdata/config.yml | awk '{print$2}'):8443 to setup your account.
+check_command ./bitwarden.sh updatedb
 
-After the account it setup, please disable user registration by running sudo bash $SCRIPTS/menu.sh and choose:
-Additional Apps --> Bitwarden Registration"
-else
-msg_box "Bitwarden installation failed! We will now remove necessary configs to be able to run this script again"
-    rm -rf /root/bwdata/
+# Produce reverse-proxy config and get lets-encrypt certificate
+
+# Curl the lib another time to get the correct HTTPS_CONF
+. <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
+
+# Check if $SUBDOMAIN exists and is reachable
+print_text_in_color "$ICyan" "Checking if $SUBDOMAIN exists and is reachable..."
+domain_check_200 "$SUBDOMAIN"
+
+# Check open ports with NMAP
+check_open_port 80 "$SUBDOMAIN"
+check_open_port 443 "$SUBDOMAIN"
+
+# Install Apache2
+install_if_not apache2
+
+# Enable Apache2 module's
+a2enmod proxy
+a2enmod proxy_wstunnel
+a2enmod proxy_http
+a2enmod ssl
+
+if [ -f "$HTTPS_CONF" ]
+then
+    a2dissite "$SUBDOMAIN.conf"
+    rm -f "$HTTPS_CONF"
 fi
 
-# Start Apache2
+if [ ! -f "$HTTPS_CONF" ];
+then
+    cat << HTTPS_CREATE > "$HTTPS_CONF"
+<VirtualHost *:443>
+    ServerName $SUBDOMAIN:443
+    SSLEngine on
+    ServerSignature On
+    SSLHonorCipherOrder on
+    SSLCertificateChainFile $CERTFILES/$SUBDOMAIN/chain.pem
+    SSLCertificateFile $CERTFILES/$SUBDOMAIN/cert.pem
+    SSLCertificateKeyFile $CERTFILES/$SUBDOMAIN/privkey.pem
+    SSLOpenSSLConfCmd DHParameters $DHPARAMS_SUB
+    
+    SSLProtocol             all -SSLv2 -SSLv3
+    SSLCipherSuite ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
+    LogLevel warn
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    # Just in case - see below
+    SSLProxyEngine On
+    SSLProxyVerify None
+    SSLProxyCheckPeerCN Off
+    SSLProxyCheckPeerName Off
+    # contra mixed content warnings
+    RequestHeader set X-Forwarded-Proto "https"
+    # basic proxy settings
+    ProxyRequests off
+    ProxyPassMatch (.*)(\/websocket)$ "ws://127.0.0.1:5178/$1$2"
+    ProxyPass / "http://127.0.0.1:5178/"
+    ProxyPassReverse / "http://127.0.0.1:5178/"
+        
+    <Location />
+        ProxyPassReverse /
+    </Location>
+</VirtualHost>
+HTTPS_CREATE
+
+    if [ -f "$HTTPS_CONF" ];
+    then
+        print_text_in_color "$IGreen" "$HTTPS_CONF was successfully created."
+        sleep 1
+    else
+        print_text_in_color "$IRed" "Unable to create vhost, exiting..."
+        print_text_in_color "$IRed" "Please report this issue here $ISSUES"
+        exit 1
+    fi
+fi
+
+# Install certbot (Let's Encrypt)
+install_certbot
+
+# Generate certs and  auto-configure  if successful
+if generate_cert  "$SUBDOMAIN"
+then
+    # Generate DHparams chifer
+    if [ ! -f "$DHPARAMS_SUB" ]
+    then
+        openssl dhparam -dsaparam -out "$DHPARAMS_SUB" 4096
+    fi
+    print_text_in_color "$IGreen" "Certs are generated!"
+    a2ensite "$SUBDOMAIN.conf"
+    restart_webserver
+else
+    last_fail_tls "$SCRIPTS"/apps/tmbitwarden.sh
+fi
+
+# Add prune command
+{
+echo "#!/bin/bash"
+echo "docker system prune -a --force"
+echo "exit"
+} > "$SCRIPTS/dockerprune.sh"
+chmod a+x "$SCRIPTS/dockerprune.sh"
+crontab -u root -l | { cat; echo "@weekly $SCRIPTS/dockerprune.sh"; } | crontab -u root -
+print_text_in_color "$ICyan" "Docker automatic prune job added."
 check_command systemctl start apache2.service
+
+msg_box "Bitwarden was sucessfully installed! Please visit $SUBDOMAIN to setup your account.
+
+# After the account it setup, please disable user registration by running sudo bash $SCRIPTS/menu.sh and choose:
+# Additional Apps --> Bitwarden Registration"
 
 exit

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -207,7 +207,7 @@ then
     restart_webserver
 else
     # remove settings to be able to start over again
-    rm -f $HTTPS_CONF
+    rm -f "$HTTPS_CONF"
     last_fail_tls "$SCRIPTS"/apps/tmbitwarden.sh
     check_command docker stop bitwarden-nginx bitwarden-admin bitwarden-events bitwarden-attachments \
     bitwarden-identity bitwarden-api bitwarden-web bitwarden-icons bitwarden-notifications bitwarden-mssql

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -41,8 +41,8 @@ print_text_in_color "$ICyan" "Installing Bitwarden password manager..."
 
 msg_box "Bitwarden is a password manager that is seperate from Nextcloud, though we provide this service because it's self hosted and secure.
 
-If you on the other hand want to run this on a subdomain, then please create a DNS record and point it to this server.
-In the process of setting up Bitwarden you will be asked to generate an TLS cert with Let's Enrypt so no need to get your own prior to this setup.
+To be able to use Bitwarden, you need a seperate subdomain. Please create a DNS record and point it to this server, e.g: bitwarden.yourdomain.com.
+After Bitwarden is setup, we will automatically generate a TLS cert with Let's Enrypt. There's no need to get your own prior to this setup, nor during the Bitwarden setup.
 
 The script is based on this documentation: https://help.bitwarden.com/article/install-on-premise/
 It's a good idea to read that before you start this script.
@@ -62,20 +62,22 @@ To run this script again, execute $SCRIPTS/menu.sh and choose Additional Apps --
     exit
 fi
 
-msg_box "ATTENTION!
+msg_box "IMPORTANT, PLEASE READ!
 
-You will see in the next step a setup which is provided by bitwarden.
-You have to make your choices based on the following instructions, 
-otherwise things can go wrong since we have no influence on those scripts.
-Best is if you take a picture of those instructions so that you remember them later on.
-And please don't worry: we will create a valid SSL certificate afterwards ourselves.
+In the next steps you will be asked to answer some questions.
+The questions are from the Bitwarden setup script, and therefore nothing that we control.
 
-1. Enter your subdomain like e.g. 'bitwarden.example.com'
-2. You will be asked if you want to use 'lets encrypt'; Please type in no: 'n'
-3. Enter your installation ID, which you must get on https://bitwarden.com/host
-4. Enter your installation key, which you will also get there
-5. You will be asked if you have a SSL certificate which you want to use; Please type in no: 'n'
-6. You will be asked if you want to generate a self-signed SSL certificate; Please type in no: 'n'"
+It's important that you answer the questions correclty for the rest of the setup to work properly,
+and to be able to generate a valid TLS certificate automatically with our own (this) script.
+
+Basically:
+1. Enter the domain for Bitwarden
+2. Answer 'no' to the question if you want Let's Encrypt
+3. Enter your installation id and keys
+4. Continue to answer 'no' to everything related to SSL/TLS.
+
+Please have a look at how the questions are answered here if you are uncertain:
+https://i.imgur.com/YPynDAf.png"
 
 # Install Docker
 install_docker

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -92,6 +92,17 @@ cd /root
 curl_to_dir "https://raw.githubusercontent.com/bitwarden/core/master/scripts" "bitwarden.sh" "/root"
 chmod +x /root/bitwarden.sh
 check_command ./bitwarden.sh install
+
+# Check if alls ssl settings were entered correctly
+if grep ^url /root/bwdata/config.yml | grep -q https || grep ^url /root/bwdata/config.yml | grep -q localhost
+then
+    message "It seems like you have entered some wrong settings. We will remove bitwarden now again so that you can start over again."
+    check_command docker rm bitwarden-nginx bitwarden-admin bitwarden-events bitwarden-attachments \
+    bitwarden-identity bitwarden-api bitwarden-web bitwarden-icons bitwarden-notifications bitwarden-mssql
+    rm -rf /root/bwdata
+fi
+
+# Continue with the installation
 sed -i "s|http_port.*|http_port: 5178|g" /root/bwdata/config.yml
 sed -i "s|https_port.*|https_port: 5179|g" /root/bwdata/config.yml
 # Get Subdomain from config.yml and change it to https

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -100,6 +100,7 @@ then
     check_command docker rm bitwarden-nginx bitwarden-admin bitwarden-events bitwarden-attachments \
     bitwarden-identity bitwarden-api bitwarden-web bitwarden-icons bitwarden-notifications bitwarden-mssql
     rm -rf /root/bwdata
+    exit 1
 fi
 
 # Continue with the installation

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -115,7 +115,7 @@ check_command ./bitwarden.sh start
 check_command ./bitwarden.sh updatedb
 
 # Produce reverse-proxy config and get lets-encrypt certificate
-msg_box "We will not setup the Apache Proxy that will act as TLS front for your Bitwarden installation."
+msg_box "We'll now setup the Apache Proxy that will act as TLS front for your Bitwarden installation."
 
 # Curl the lib another time to get the correct HTTPS_CONF
 # shellcheck disable=2034,2059

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -93,7 +93,7 @@ curl_to_dir "https://raw.githubusercontent.com/bitwarden/core/master/scripts" "b
 chmod +x /root/bitwarden.sh
 check_command ./bitwarden.sh install
 
-# Check if alls ssl settings were entered correctly
+# Check if all ssl settings were entered correctly
 if grep ^url /root/bwdata/config.yml | grep -q https || grep ^url /root/bwdata/config.yml | grep -q localhost
 then
     message "It seems like you have entered some wrong settings. We will remove bitwarden now again so that you can start over again."
@@ -206,7 +206,15 @@ then
     a2ensite "$SUBDOMAIN.conf"
     restart_webserver
 else
+    # remove settings to be able to start over again
+    rm -f $HTTPS_CONF
     last_fail_tls "$SCRIPTS"/apps/tmbitwarden.sh
+    check_command docker stop bitwarden-nginx bitwarden-admin bitwarden-events bitwarden-attachments \
+    bitwarden-identity bitwarden-api bitwarden-web bitwarden-icons bitwarden-notifications bitwarden-mssql
+    check_command docker rm bitwarden-nginx bitwarden-admin bitwarden-events bitwarden-attachments \
+    bitwarden-identity bitwarden-api bitwarden-web bitwarden-icons bitwarden-notifications bitwarden-mssql
+    rm -rf /root/bwdata
+    exit 1
 fi
 
 # Add prune command

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -83,9 +83,6 @@ https://i.imgur.com/YPynDAf.png"
 install_docker
 install_if_not docker-compose
 
-# Stop Apache to not conflict when LE is run
-check_command systemctl stop apache2.service
-
 # Install Bitwarden 
 install_if_not curl
 cd /root
@@ -216,15 +213,7 @@ else
 fi
 
 # Add prune command
-{
-echo "#!/bin/bash"
-echo "docker system prune -a --force"
-echo "exit"
-} > "$SCRIPTS/dockerprune.sh"
-chmod a+x "$SCRIPTS/dockerprune.sh"
-crontab -u root -l | { cat; echo "@weekly $SCRIPTS/dockerprune.sh"; } | crontab -u root -
-print_text_in_color "$ICyan" "Docker automatic prune job added."
-check_command systemctl start apache2.service
+add_dockerprune
 
 msg_box "Bitwarden was sucessfully installed! Please visit $SUBDOMAIN to setup your account.
 

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -119,6 +119,9 @@ check_command ./bitwarden.sh updatedb
 msg_box "We will not setup the Apache Proxy that will act as TLS front for your Bitwarden installation."
 
 # Curl the lib another time to get the correct HTTPS_CONF
+# shellcheck disable=2034,2059
+true
+# shellcheck source=lib.sh
 . <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
 
 # Check if $SUBDOMAIN exists and is reachable

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -104,6 +104,7 @@ check_command ./bitwarden.sh start
 check_command ./bitwarden.sh updatedb
 
 # Produce reverse-proxy config and get lets-encrypt certificate
+msg_box "We will not setup the Apache Proxy that will act as TLS front for your Bitwarden installation."
 
 # Curl the lib another time to get the correct HTTPS_CONF
 . <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -97,8 +97,7 @@ check_command ./bitwarden.sh install
 if grep ^url /root/bwdata/config.yml | grep -q https || grep ^url /root/bwdata/config.yml | grep -q localhost
 then
     message "It seems like you have entered some wrong settings. We will remove bitwarden now again so that you can start over again."
-    check_command docker rm bitwarden-nginx bitwarden-admin bitwarden-events bitwarden-attachments \
-    bitwarden-identity bitwarden-api bitwarden-web bitwarden-icons bitwarden-notifications bitwarden-mssql
+    ./bitwarden stop && docker system prune -af
     rm -rf /root/bwdata
     exit 1
 fi
@@ -213,10 +212,7 @@ else
     # remove settings to be able to start over again
     rm -f "$HTTPS_CONF"
     last_fail_tls "$SCRIPTS"/apps/tmbitwarden.sh
-    check_command docker stop bitwarden-nginx bitwarden-admin bitwarden-events bitwarden-attachments \
-    bitwarden-identity bitwarden-api bitwarden-web bitwarden-icons bitwarden-notifications bitwarden-mssql
-    check_command docker rm bitwarden-nginx bitwarden-admin bitwarden-events bitwarden-attachments \
-    bitwarden-identity bitwarden-api bitwarden-web bitwarden-icons bitwarden-notifications bitwarden-mssql
+    ./bitwarden stop && docker system prune -af
     rm -rf /root/bwdata
     exit 1
 fi

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -230,7 +230,7 @@ check_command systemctl start apache2.service
 
 msg_box "Bitwarden was sucessfully installed! Please visit $SUBDOMAIN to setup your account.
 
-# After the account it setup, please disable user registration by running sudo bash $SCRIPTS/menu.sh and choose:
-# Additional Apps --> Bitwarden Registration"
+After the account it setup, please disable user registration by running sudo bash $SCRIPTS/menu.sh and choose:
+Additional Apps --> Bitwarden Registration"
 
 exit

--- a/apps/tmbitwarden.sh
+++ b/apps/tmbitwarden.sh
@@ -118,8 +118,6 @@ check_command ./bitwarden.sh updatedb
 msg_box "We'll now setup the Apache Proxy that will act as TLS front for your Bitwarden installation."
 
 # Curl the lib another time to get the correct HTTPS_CONF
-# shellcheck disable=2034,2059
-true
 # shellcheck source=lib.sh
 . <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
 

--- a/lib.sh
+++ b/lib.sh
@@ -1329,6 +1329,19 @@ export PHP_POOL_DIR=/etc/php/"$PHPVER"/fpm/pool.d
 print_text_in_color "$IGreen" PHPVER="$PHPVER"
 }
 
+add_dockerprune() {
+print_text_in_color "$ICyan" "Adding cronjob for Docker weekly prune..."
+if ! crontab -u root -l | grep -q 'dockerprune.sh'
+then
+    crontab -u root -l | { cat; echo "@weekly $SCRIPTS/dockerprune.sh"; } | crontab -u root -
+    check_command echo "#!/bin/bash" > "$SCRIPTS/dockerprune.sh"
+    check_command echo "docker system prune -a --force" >> "$SCRIPTS/dockerprune.sh"
+    check_command echo "exit" >> "$SCRIPTS/dockerprune.sh"
+    chmod a+x "$SCRIPTS"/dockerprune.sh
+    print_text_in_color "$IGreen" "Docker automatic prune job added."
+fi
+}
+
 ## bash colors
 # Reset
 Color_Off='\e[0m'       # Text Reset

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -531,7 +531,7 @@ Please check in $BACKUP if the folders exist."
 fi
 
 # Update Bitwarden
-if [ "$(docker ps -a >/dev/null 2>&1 && echo yes || echo no)" == "yes" ]
+if [ s_docker_running ]
 then
     if docker ps -a --format '{{.Names}}' | grep -Eq "bitwarden";
     then

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -531,7 +531,7 @@ Please check in $BACKUP if the folders exist."
 fi
 
 # Update Bitwarden
-if [ s_docker_running ]
+if [ is_docker_running ]
 then
     if docker ps -a --format '{{.Names}}' | grep -Eq "bitwarden";
     then

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -531,7 +531,7 @@ Please check in $BACKUP if the folders exist."
 fi
 
 # Update Bitwarden
-if [ is_docker_running ]
+if is_docker_running
 then
     if docker ps -a --format '{{.Names}}' | grep -Eq "bitwarden";
     then

--- a/old/onlyoffice.sh
+++ b/old/onlyoffice.sh
@@ -203,15 +203,9 @@ then
     occ_command config:app:set onlyoffice DocumentServerUrl --value=https://"$SUBDOMAIN/"
     chown -R www-data:www-data "$NC_APPS_PATH"
     occ_command config:system:set trusted_domains 3 --value="$SUBDOMAIN"
-# Add prune command
-    {
-    echo "#!/bin/bash"
-    echo "docker system prune -a --force"
-    echo "exit"
-    } > "$SCRIPTS/dockerprune.sh"
-    chmod a+x "$SCRIPTS/dockerprune.sh"
-    crontab -u root -l | { cat; echo "@weekly $SCRIPTS/dockerprune.sh"; } | crontab -u root -
-    print_text_in_color "$ICyan" "Docker automatic prune job added."
+    # Add prune command
+    add_dockerprune
+    # Restart Docker
     service docker restart
     docker restart onlyoffice
     print_text_in_color "$IGreen" "OnlyOffice is now successfully installed."


### PR DESCRIPTION
second attempt to fix #1336

What works is the proxy: 
- you have access to bitwarden after executing the script on your subdomain with tls

What doesn't work on my local test machine with not enough specs: 
- creating a bitwarden account.

What we should do next, imo:
1. test it on a VPS with enough specs
2. if creating an admin account doesn't work there, neither: try to implement the proxy settings from here: bitwarden/server#314
3. If creating an admin account doesn't work after step 2, try to use localhost as the domain during the bitwarden setup instead of the real subdomain and don't change anything in config.yml and globaloverride to https://.
Additionally, ask for a subdomain first.
4. Now it should definitely work.
5. create some tests to make it more reliable and reset everything to the default, if anything goes wrong