### PR TITLE
use logrotate for nextcloud logs

### DIFF
--- a/menu/nextcloud_configuration.sh
+++ b/menu/nextcloud_configuration.sh
@@ -78,14 +78,14 @@ case "$choice" in
 
             # Configure logrotate to rotate logs for us (max 10, every day a new one)
             cat << NEXTCLOUD_CONF > /etc/logrotate.d/nextcloud.log.conf
-            $VMLOGS/nextcloud.log {
-            daily
-            rotate 10
-            }
-            NEXTCLOUD_CONF
+$VMLOGS/nextcloud.log {
+daily
+rotate 10
+}
+NEXTCLOUD_CONF
 
             # Set needed ownerchip for the nextcloud log folder to work correctly
-            chown "${htuser}":"${htgroup}" "${VMLOGS}"/
+            chown www-data:www-data "${VMLOGS}"/
         fi
     ;;&
     *)

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -427,8 +427,15 @@ occ_command config:system:set mail_smtpmode --value="smtp"
 # Forget login/session after 30 minutes
 occ_command config:system:set remember_login_cookie_lifetime --value="1800"
 
-# Set logrotate (max 10 MB)
-occ_command config:system:set log_rotate_size --value="10485760"
+# Set logrotate (without size restriction)
+occ_command config:system:set log_rotate_size --value=0
+
+# Configure logrotate to rotate logs for us (max 10, every day a new one)
+touch /etc/logrotate.d/nextcloud.log.conf
+"/var/log/nextcloud/nextcloud.log {
+daily
+rotate 10
+}" > /etc/logrotate.d/nextcloud.log.conf
 
 # Set trashbin retention obligation (save it in trahbin for 6 months or delete when space is needed)
 occ_command config:system:set trashbin_retention_obligation --value="auto, 180"

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -432,7 +432,7 @@ occ_command config:system:set log_rotate_size --value=0
 
 # Configure logrotate to rotate logs for us (max 10, every day a new one)
 touch /etc/logrotate.d/nextcloud.log.conf
-"/var/log/nextcloud/nextcloud.log {
+"$VMLOGS/nextcloud.log {
 daily
 rotate 10
 }" > /etc/logrotate.d/nextcloud.log.conf

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -427,16 +427,8 @@ occ_command config:system:set mail_smtpmode --value="smtp"
 # Forget login/session after 30 minutes
 occ_command config:system:set remember_login_cookie_lifetime --value="1800"
 
-# Set logrotate (without size restriction)
-occ_command config:system:set log_rotate_size --value=0
-
-# Configure logrotate to rotate logs for us (max 10, every day a new one)
-cat << NEXTCLOUD_CONF > /etc/logrotate.d/nextcloud.log.conf
-$VMLOGS/nextcloud.log {
-daily
-rotate 10
-}
-NEXTCLOUD_CONF
+# Set logrotate (max 10 MB)
+occ_command config:system:set log_rotate_size --value="10485760"
 
 # Set trashbin retention obligation (save it in trahbin for 6 months or delete when space is needed)
 occ_command config:system:set trashbin_retention_obligation --value="auto, 180"

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -431,11 +431,12 @@ occ_command config:system:set remember_login_cookie_lifetime --value="1800"
 occ_command config:system:set log_rotate_size --value=0
 
 # Configure logrotate to rotate logs for us (max 10, every day a new one)
-touch /etc/logrotate.d/nextcloud.log.conf
-"$VMLOGS/nextcloud.log {
+cat << NEXTCLOUD_CONF > /etc/logrotate.d/nextcloud.log.conf
+$VMLOGS/nextcloud.log {
 daily
 rotate 10
-}" > /etc/logrotate.d/nextcloud.log.conf
+}
+NEXTCLOUD_CONF
 
 # Set trashbin retention obligation (save it in trahbin for 6 months or delete when space is needed)
 occ_command config:system:set trashbin_retention_obligation --value="auto, 180"

--- a/static/setup_secure_permissions_nextcloud.sh
+++ b/static/setup_secure_permissions_nextcloud.sh
@@ -76,7 +76,7 @@ print_text_in_color "$ICyan" "chmod/chown .htaccess"
 if [ -f "${NCPATH}"/.htaccess ]
 then
     chmod 0644 "${NCPATH}"/.htaccess
-    chown "${htgroup}":"${htgroup}" "${NCPATH}"/.htaccess
+    chown "${rootuser}":"${htgroup}" "${NCPATH}"/.htaccess
 fi
 if [ -f "${NCDATA}"/.htaccess ]
 then

--- a/static/setup_secure_permissions_nextcloud.sh
+++ b/static/setup_secure_permissions_nextcloud.sh
@@ -52,6 +52,7 @@ find "${VMLOGS}"/nextcloud.log -type f -print0 | xargs -0 chmod 0640
 
 print_text_in_color "$ICyan" "chown Directories"
 chown -R "${rootuser}":"${htgroup}" "${VMLOGS}"/
+chown "${htuser}":"${htgroup}" "${VMLOGS}"/
 chown "${htuser}":"${htgroup}" "${VMLOGS}"/nextcloud.log
 chown "${htuser}":"${htgroup}" "${VMLOGS}"/audit.log
 chown -R "${rootuser}":"${htgroup}" "${NCPATH}"/
@@ -75,7 +76,7 @@ print_text_in_color "$ICyan" "chmod/chown .htaccess"
 if [ -f "${NCPATH}"/.htaccess ]
 then
     chmod 0644 "${NCPATH}"/.htaccess
-    chown "${rootuser}":"${htgroup}" "${NCPATH}"/.htaccess
+    chown "${htgroup}":"${htgroup}" "${NCPATH}"/.htaccess
 fi
 if [ -f "${NCDATA}"/.htaccess ]
 then


### PR DESCRIPTION
first attempt to fix #1280

for testing probably use `logrotate --force  /etc/logrotate.d/nextcloud.log.conf`
(https://stackoverflow.com/questions/2117771/is-it-possible-to-run-one-logrotate-check-manually)

How logrotate works
The system runs logrotate on a schedule, usually daily. On most distributions, the script that runs logrotate daily is located at /etc/cron.daily/logrotate.

Some distributions use a variation. For example, on Gentoo the logrotate script is located at /etc/cron.daily/logrotate.cron.