### PR TITLE
Fixed reference to script name change

### DIFF
--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -184,13 +184,13 @@ case "$choice" in
     "2 Disks Auto")
         run_script DISK format-sdb
         # Change to zfs-mount-generator
-        run_script DISK zfs-prune-snapshots.sh
+        run_script DISK zfs-prune-snapshots
 
     ;;
     "2 Disks Manual")
         run_script DISK format-chosen
         # Change to zfs-mount-generator
-        run_script DISK zfs-prune-snapshots.sh
+        run_script DISK zfs-prune-snapshots
     ;;
     "1 Disk")
         print_text_in_color "$IRed" "1 Disk setup chosen."

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -184,13 +184,13 @@ case "$choice" in
     "2 Disks Auto")
         run_script DISK format-sdb
         # Change to zfs-mount-generator
-        run_script DISK change-to-zfs-mount-generator
+        run_script DISK zfs-prune-snapshots.sh
 
     ;;
     "2 Disks Manual")
         run_script DISK format-chosen
         # Change to zfs-mount-generator
-        run_script DISK change-to-zfs-mount-generator
+        run_script DISK zfs-prune-snapshots.sh
     ;;
     "1 Disk")
         print_text_in_color "$IRed" "1 Disk setup chosen."


### PR DESCRIPTION
The name of the script change-to-zfs-mount-generator was changed to zfs-prune-snapshots.sh in commit f9c9e0d in /vm/disk. This breaks the install process as it fails to download. This PR changes the name to the correct name. Honestly this is my first time on github and I'm not too sure if this is the right way to do this but I couldn't find any other references to that script so hopefully it's correct. Apologies for any inconvenience!