### PR TITLE
further improvements to Talk Signaling

### DIFF
--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -369,6 +369,7 @@ then
     ProxyPass /error/ !
     ErrorDocument 404 /error/404_proxy.html
     # Enable proxying Websocket requests to the standalone signaling server.
+    # https://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html
     ProxyPass / "http://127.0.0.1:8081/"
     RewriteEngine on
     RewriteCond %{HTTP:Upgrade} websocket [NC]

--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -226,6 +226,12 @@ then
     exit 1
 fi
 
+SUBDOMAIN=$(whiptail --title "T&M Hansson IT - Talk Signaling Server" --inputbox "Talk Signaling Server subdomain eg: talk.yourdomain.com\n\nNOTE: This domain must be different than your Nextcloud domain. They can however be hosted on the same server, but would require seperate DNS entries." "$WT_HEIGHT" "$WT_WIDTH" 3>&1 1>&2 2>&3)
+
+# curl the lib another time to get the correct https_conf
+# shellcheck source=lib.sh
+. <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
+
 # Check if $SUBDOMAIN exists and is reachable
 print_text_in_color "$ICyan" "Checking if $SUBDOMAIN exists and is reachable..."
 domain_check_200 "$SUBDOMAIN"

--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -259,7 +259,7 @@ sed -i "s|#turn_rest_api_key\s*=.*|$JANUS_API_KEY|" /etc/janus/janus.jcfg
 sed -i "s|#full_trickle|full_trickle|g" /etc/janus/janus.jcfg
 sed -i 's|#interface.*|interface = "lo"|g' /etc/janus/janus.transport.websockets.jcfg
 sed -i 's|#ws_interface.*|ws_interface = "lo"|g' /etc/janus/janus.transport.websockets.jcfg
-check_command systemctl restart janus
+start_if_stopped janus
 check_command systemctl enable janus
 
 # HPB
@@ -295,10 +295,10 @@ url = ws://127.0.0.1:8188
 [turn]
 apikey = ${JANUS_API_KEY}
 secret = ${TURN_SECRET}
-servers = turn:$TURN_DOMAIN:$TURN_PORT?transport=tcp
+servers = turn:$TURN_DOMAIN:$TURN_PORT?transport=tcp,turn:$TURN_DOMAIN:$TURN_PORT?transport=udp
 SIGNALING_CONF_CREATE
 fi
-check_command systemctl restart signaling
+start_if_stopped signaling
 check_command systemctl enable signaling
 
 ### PROXY ###
@@ -344,8 +344,8 @@ then
     SSLProtocol TLSv1.2
     SSLCipherSuite ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
     LogLevel warn
-    CustomLog ${APACHE_LOG_DIR}/access.log combined
-    ErrorLog ${APACHE_LOG_DIR}/error.log
+#    CustomLog $VMLOGS/talk_apache_access.log
+#    ErrorLog $VMLOGS/talk_apache_error.log
     # Just in case - see below
     SSLProxyEngine On
     SSLProxyVerify None
@@ -399,7 +399,13 @@ else
     # remove settings to be able to start over again
     rm -f "$HTTPS_CONF"
     last_fail_tls "$SCRIPTS"/apps/talk_signaling.sh
-    
-    msg_box "Please run this script again to uninstall if you want clean system, or reinstall if you want to try again."
     exit 1
+fi
+
+# Check that everything is working
+if ! curl -L https://"$SUBDOMAIN"/api/v1/welcome
+then
+    msg_box "Installationn failed. :/\n\nPlease run this script again to uninstall if you want clean system, or reinstall if you want to try again."
+else
+   msg_box "Congratulations, everything is working as intended! The installation succeeded."
 fi

--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -361,12 +361,11 @@ then
     RequestHeader set X-Forwarded-Proto "https"
     # basic proxy settings
     # Enable proxying Websocket requests to the standalone signaling server.
-    ProxyPass "/"  "ws://127.0.0.1:8081/"
-    RewriteEngine On
-    # Websocket connections from the clients.
-    RewriteRule ^/spreed$ - [L]
-    # Backend connections from Nextcloud.
-    RewriteRule ^/api/(.*) http://127.0.0.1:8081/api/\$1 [L,P]
+    ProxyPass / "http://127.0.0.1:8081/"
+    RewriteEngine on
+    RewriteCond %{HTTP:Upgrade} websocket [NC]
+    RewriteCond %{HTTP:Connection} upgrade [NC]
+    RewriteRule ^/?(.*) "ws://127.0.0.1:8081/\$1" [P,L]
     # Extra (remote) headers
     RequestHeader set X-Real-IP %{REMOTE_ADDR}s
     Header set X-XSS-Protection "1; mode=block"

--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -336,7 +336,7 @@ chown www-data:www-data $VMLOGS/talk_apache_error.log $VMLOGS/talk_apache_access
 
 # Prep the error page
 mkdir -p /var/www/html/error
-echo "hi there! :)" > /var/www/html/error/404_proxy.html
+echo "Hi there! :) If you see this page, the Apache2 proxy for $DESCRIPTION is up and running." > /var/www/html/error/404_proxy.html
 
 if [ -f "$HTTPS_CONF" ]
 then

--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -336,6 +336,7 @@ chown www-data:www-data $VMLOGS/talk_apache_error.log $VMLOGS/talk_apache_access
 
 # Prep the error page
 mkdir -p /var/www/html/error
+chown -R www-data:www-data /var/www/html/error
 echo "Hi there! :) If you see this page, the Apache2 proxy for $DESCRIPTION is up and running." > /var/www/html/error/404_proxy.html
 
 if [ -f "$HTTPS_CONF" ]

--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -425,7 +425,7 @@ fi
 # Check that everything is working
 if ! curl -L https://"$SUBDOMAIN"/api/v1/welcome
 then
-    msg_box "Installationn failed. :/\n\nPlease run this script again to uninstall if you want clean system, or reinstall if you want to try again."
+    msg_box "Installationn failed. :/\n\nPlease run this script again to uninstall if you want clean system, or reinstall if you want to try again.\n\nLogging can be found by typing: journalctl -lfu signaling"
 else
-   msg_box "Congratulations, everything is working as intended! The installation succeeded."
+   msg_box "Congratulations, everything is working as intended! The installation succeeded.\n\nLogging can be found by typing: journalctl -lfu signaling"
 fi

--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -329,6 +329,11 @@ a2enmod ssl
 a2enmod headers
 a2enmod remoteip
 
+# Allow CustomLog
+touch $VMLOGS/talk_apache_access.log
+touch $VMLOGS/talk_apache_error.log
+chown www-data:www-data $VMLOGS/talk_apache_error.log $VMLOGS/talk_apache_access.log
+
 # Prep the error page
 mkdir -p /var/www/html/error
 echo "hi there! :)" > /var/www/html/error/404_proxy.html
@@ -354,8 +359,8 @@ then
     SSLProtocol TLSv1.2
     SSLCipherSuite ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
     LogLevel warn
-#    CustomLog $VMLOGS/talk_apache_access.log
-#    ErrorLog $VMLOGS/talk_apache_error.log
+    CustomLog $VMLOGS/talk_apache_access.log combined
+    ErrorLog $VMLOGS/talk_apache_error.log
     # Just in case - see below
     SSLProxyEngine On
     SSLProxyVerify None

--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -331,7 +331,7 @@ a2enmod remoteip
 
 # Prep the error page
 mkdir -p /var/www/html/error
-echo "hi there! :)" > /error/404_proxy.html
+echo "hi there! :)" > /var/www/html/error/404_proxy.html
 
 if [ -f "$HTTPS_CONF" ]
 then

--- a/apps/talk_signaling.sh
+++ b/apps/talk_signaling.sh
@@ -329,6 +329,10 @@ a2enmod ssl
 a2enmod headers
 a2enmod remoteip
 
+# Prep the error page
+mkdir -p /var/www/html/error
+echo "hi there! :)" > /error/404_proxy.html
+
 if [ -f "$HTTPS_CONF" ]
 then
     a2dissite "$SUBDOMAIN.conf"
@@ -359,7 +363,11 @@ then
     SSLProxyCheckPeerName Off
     # contra mixed content warnings
     RequestHeader set X-Forwarded-Proto "https"
-    # basic proxy settings
+    # Custom error page
+    ProxyErrorOverride On
+    DocumentRoot "/var/www/html"
+    ProxyPass /error/ !
+    ErrorDocument 404 /error/404_proxy.html
     # Enable proxying Websocket requests to the standalone signaling server.
     ProxyPass / "http://127.0.0.1:8081/"
     RewriteEngine on

--- a/lib.sh
+++ b/lib.sh
@@ -159,7 +159,6 @@ APACHE2=/etc/apache2/apache2.conf
 [ -n "$TURN_INSTALL" ] && TURN_DOMAIN=$(sudo -u www-data /var/www/nextcloud/occ config:system:get overwrite.cli.url | sed 's#https://##;s#/##')
 [ -n "$TURN_INSTALL" ] && SHUF=$(shuf -i 25-29 -n 1)
 [ -n "$TURN_INSTALL" ] && TURN_SECRET=$(gen_passwd "$SHUF" "a-zA-Z0-9@#*=")
-[ -n "$TURN_INSTALL" ] && SUBDOMAIN=$(whiptail --title "T&M Hansson IT - Talk Signaling Server" --inputbox "Talk Signaling Server subdomain eg: talk.yourdomain.com\n\nNOTE: This domain must be different than your Nextcloud domain. They can however be hosted on the same server, but would require seperate DNS entries." "$WT_HEIGHT" "$WT_WIDTH" 3>&1 1>&2 2>&3)
 [ -n "$TURN_INSTALL" ] && JANUS_API_KEY=$(gen_passwd "$SHUF" "a-zA-Z0-9@#*=")
 [ -n "$TURN_INSTALL" ] && NC_SECRET=$(gen_passwd "$SHUF" "a-zA-Z0-9@#*=")
 [ -n "$TURN_INSTALL" ] && SIGNALING_SERVER_CONF=/etc/signaling/server.conf

--- a/menu/additional_apps.sh
+++ b/menu/additional_apps.sh
@@ -109,7 +109,7 @@ case "$choice" in
     *"Talk"*)
         clear
         print_text_in_color "$ICyan" "Downloading the Talk script..."
-        run_script APP talk
+        run_script APP talk_signaling
     ;;&
     *"Webmin"*)
         clear


### PR DESCRIPTION
@morph027 @szaimen 

Still internal server error, but Nextcloud reports OK, and curl command works.

**Apache2 log**
```
[Mon Aug 24 22:57:51.555540 2020] [proxy:warn] [pid 64118:tid 140500374681344] [client 5.243.70.111:60706] AH01144: No protocol handler was valid for the URL /favicon.ico (scheme 'ws'). If you are using a DSO version of mod_proxy, make sure the proxy submodules are included in the configuration using LoadModule.
```

Apache also needs access to the logs dir.