### PR TITLE
fix first internet check on startup-script and static_ip and remove it from server_configuration

### DIFF
--- a/menu/server_configuration.sh
+++ b/menu/server_configuration.sh
@@ -2,6 +2,12 @@
 
 # T&M Hansson IT AB © - 2020, https://www.hanssonit.se/
 
+# shellcheck disable=2034,2059
+true
+SCRIPT_NAME="Server Configuration Menu"
+# shellcheck source=lib.sh
+. <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
+
 # Check for errors + debug code and abort if something isn't right
 # 1 = ON
 # 0 = OFF

--- a/menu/server_configuration.sh
+++ b/menu/server_configuration.sh
@@ -2,27 +2,6 @@
 
 # T&M Hansson IT AB © - 2020, https://www.hanssonit.se/
 
-# If we have internet, then use the latest variables from the lib remote file
-if printf "Testing internet connection..." && ping github.com -c 2
-then
-# shellcheck disable=2034,2059
-true
-SCRIPT_NAME="Server Configuration Menu"
-# shellcheck source=lib.sh
-. <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
-# Use local lib file in case there is no internet connection
-elif [ -f /var/scripts/lib.sh ]
-then
-# shellcheck disable=2034,2059
-true
-# shellcheck source=lib.sh
-source /var/scripts/lib.sh
-else
-    printf "You don't seem to have a working internet connection, and /var/scripts/lib.sh is missing so you can't run this script."
-    printf "Please report this to https://github.com/nextcloud/vm/issues/"
-    exit 1
-fi
-
 # Check for errors + debug code and abort if something isn't right
 # 1 = ON
 # 0 = OFF

--- a/network/static_ip.sh
+++ b/network/static_ip.sh
@@ -3,21 +3,22 @@
 # T&M Hansson IT AB © - 2020, https://www.hanssonit.se/
 
 # Use local lib file in case there is no internet connection
-if [ -f /var/scripts/lib.sh ]
+if printf "Testing internet connection..." && ping github.com -c 2 >/dev/null 2>&1
+then
+# shellcheck disable=2034,2059
+true
+SCRIPT_NAME="Static IP"
+# shellcheck source=lib.sh
+FIRST_IFACE=1 . <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
+unset FIRST_IFACE
+ # If we have internet, then use the latest variables from the lib remote file
+elif [ -f /var/scripts/lib.sh ]
 then
 # shellcheck disable=2034,2059
 true
 SCRIPT_NAME="Static IP"
 # shellcheck source=lib.sh
 FIRST_IFACE=1 source /var/scripts/lib.sh
-unset FIRST_IFACE
- # If we have internet, then use the latest variables from the lib remote file
-elif printf "Testing internet connection..." && ping github.com -c 2
-then
-# shellcheck disable=2034,2059
-true
-# shellcheck source=lib.sh
-FIRST_IFACE=1 . <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
 unset FIRST_IFACE
 else
     printf "You don't seem to have a working internet connection, and /var/scripts/lib.sh is missing so you can't run this script."

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -37,21 +37,23 @@ is_process_running apt
 is_process_running dpkg
 
 # Use local lib file in case there is no internet connection
-if [ -f /var/scripts/lib.sh ]
+if printf "Testing internet connection..." && ping github.com -c 2 >/dev/null 2>&1
+then
+# shellcheck disable=2034,2059
+true
+SCRIPT_NAME="Nextcloud First Startup Script"
+# shellcheck source=lib.sh
+NCDB=1 && FIRST_IFACE=1 . <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
+unset NCDB
+unset FIRST_IFACE
+ # If we have internet, then use the latest variables from the lib remote file
+elif [ -f /var/scripts/lib.sh ]
 then
 # shellcheck disable=2034,2059
 true
 SCRIPT_NAME="Nextcloud First Startup Script"
 # shellcheck source=lib.sh
 NCDB=1 && FIRST_IFACE=1 source /var/scripts/lib.sh
-unset NCDB
-unset FIRST_IFACE
- # If we have internet, then use the latest variables from the lib remote file
-elif printf "Testing internet connection..." && ping github.com -c 2
-then
-true
-# shellcheck source=lib.sh
-NCDB=1 && FIRST_IFACE=1 . <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
 unset FIRST_IFACE
 unset NCDB
 else


### PR DESCRIPTION
This fixes 2 points:
- The network check for server_configuration is not needed, so I removed it. 
If I am wrong with that statement, please tell me why.
- The first network check for static_ip and startup-script was wrong because it would always use the lib if it was existing and thus never use the newest lib also not if you had a working internet-connection from the beginning.