### PR TITLE
create startup_configuration and adjust server_configuration

### DIFF
--- a/menu/server_configuration.sh
+++ b/menu/server_configuration.sh
@@ -17,40 +17,38 @@ debug_mode
 # Must be root
 root_check
 
+# Set the correct switch for activate_tls
+if [ -f $SCRIPTS/activate-tls.sh ]
+then
+    ACTIVATE_TLS_SWITCH="ON"
+else
+    ACTIVATE_TLS_SWITCH="OFF"
+fi
+
 # Server configurations
 choice=$(whiptail --title "$TITLE" --checklist "Choose what you want to configure\n$CHECKLIST_GUIDE\n$MENU_GUIDE" "$WT_HEIGHT" "$WT_WIDTH" 4 \
-"Activate TLS" "(Enable HTTPS with Let's Encrypt)" ON \
-"Security" "(Add extra security based on this http://goo.gl/gEJHi7)" OFF \
 "Static IP" "(Set static IP in Ubuntu with netplan.io)" OFF \
+"Security" "(Add extra security based on this http://goo.gl/gEJHi7)" OFF \
 "DDclient Configuration" "(Use ddclient for automatic DDNS updates)" OFF \
+"Activate TLS" "(Enable HTTPS with Let's Encrypt)" "$ACTIVATE_TLS_SWITCH" \
 "Automatic updates" "(Automatically update your server every week on Sundays)" OFF \
 "Disk Check" "(Check for S.M.A.R.T errors on your disks every week on Mondays)" OFF 3>&1 1>&2 2>&3)
 
 case "$choice" in
-    *"Security"*)
-        clear
-        print_text_in_color "$ICyan" "Downloading the Security script..."
-        run_script ADDONS security
-    ;;&
     *"Static IP"*)
         clear
         print_text_in_color "$ICyan" "Downloading the Static IP script..."
         run_script NETWORK static_ip
     ;;&
+    *"Security"*)
+        clear
+        print_text_in_color "$ICyan" "Downloading the Security script..."
+        run_script ADDONS security
+    ;;&
     *"DDclient Configuration"*)
         clear
         print_text_in_color "$ICyan" "Downloading the DDclient Configuration script..."
         run_script NETWORK ddclient-configuration
-    ;;&
-    *"Automatic updates"*)
-        clear
-        print_text_in_color "$ICyan" "Downloading the Automatic Updates script..."
-        run_script ADDONS automatic_updates
-    ;;&
-    *"Disk Check"*)
-        clear
-        print_text_in_color "$ICyan" "Downloading the Disk Check script..."
-        run_script DISK smartctl
     ;;&
     *"Activate TLS"*)
         clear
@@ -81,6 +79,16 @@ https://www.techandme.se/open-port-80-443/"
         rm -f "$SCRIPTS/test-new-config.sh"
         rm -f "$SCRIPTS/activate-tls.sh"
         clear
+    ;;&
+    *"Automatic updates"*)
+        clear
+        print_text_in_color "$ICyan" "Downloading the Automatic Updates script..."
+        run_script ADDONS automatic_updates
+    ;;&
+    *"Disk Check"*)
+        clear
+        print_text_in_color "$ICyan" "Downloading the Disk Check script..."
+        run_script DISK smartctl
     ;;&
     *)
     ;;

--- a/menu/startup_configuration.sh
+++ b/menu/startup_configuration.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# T&M Hansson IT AB © - 2020, https://www.hanssonit.se/
+
+# shellcheck disable=2034,2059
+true
+SCRIPT_NAME="Startup Configuration Menu"
+# shellcheck source=lib.sh
+. <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
+
+# Check for errors + debug code and abort if something isn't right
+# 1 = ON
+# 0 = OFF
+DEBUG=0
+debug_mode
+
+# Must be root
+root_check
+
+# Get the correct keyboard layout switch
+if [ "$KEYBOARD_LAYOUT" = "us" ]
+then
+    KEYBOARD_LAYOUT_SWITCH="ON"
+else
+    KEYBOARD_LAYOUT_SWITCH="OFF"
+fi
+
+# Get the correct locate mirror switch
+if [ -z "$REPO" ]
+then
+    REPO=$(apt update -q4 && apt-cache policy | grep http | tail -1 | awk '{print $2}')
+fi
+if [ "$REPO" = "http://se.archive.ubuntu.com/ubuntu" ]
+then
+    LOCATE_MIRROR_SWITCH="ON"
+else
+    LOCATE_MIRROR_SWITCH="OFF"
+fi
+
+# Get the correct timezone switch
+if [ "$(cat /etc/timezone)" = "Etc/UTC" ]
+then
+    TIMEZONE_SWITCH="ON"
+else
+    TIMEZONE_SWITCH="OFF"
+fi
+
+# Startup configurations
+choice=$(whiptail --title "$TITLE" --checklist "Choose what you want to change\n$CHECKLIST_GUIDE\n$MENU_GUIDE" "$WT_HEIGHT" "$WT_WIDTH" 4 \
+"Keyboard Layout" "Change the keyboard layout" "$KEYBOARD_LAYOUT_SWITCH" \
+"Locate Mirror" "Change the apt-mirror for faster udpates" "$LOCATE_MIRROR_SWITCH" \
+"Timezone" "Change the timezone" "$TIMEZONE_SWITCH" 3>&1 1>&2 2>&3)
+
+case "$choice" in
+    *"Keyboard Layout"*)
+        clear
+        if ! yesno_box_yes "Current keyboard layout is $KEYBOARD_LAYOUT.\nDo you want to change keyboard layout?"
+        then
+            print_text_in_color "$ICyan" "Not changing keyboard layout..."
+            sleep 1
+            clear
+        else
+            dpkg-reconfigure keyboard-configuration
+            setupcon --force
+            # Set locales
+            run_script ADDONS locales
+            # test the keyboard settings
+            input_box "Please try out all buttons to find out if the keyboard settings were correctly applied.\nIf this isn't the case, you will have the chance to reboot the server in the next step.\n\nPlease continue by hitting [ENTER]" >/dev/null
+            if yesno_box_no "Do you want to reboot the server?\nPlease only choose 'Yes' if the keyboard settings weren't correctly applied.\n\nIf you choose 'Yes' and the server is rebooted, please login as usual and run this script again."
+            then
+                reboot
+            fi
+        fi
+    ;;&
+    *"Locate Mirror"*)
+        clear
+        print_text_in_color "$ICyan" "Downloading the Locate Mirror script..."
+        run_script ADDONS locate_mirror
+    ;;&
+    *"Timezone"*)
+        clear
+        if ! yesno_box_yes "Current timezone is $(cat /etc/timezone).\nDo you want to change the timezone?"
+        then
+            print_text_in_color "$ICyan" "Not changing timezone..."
+            sleep 1
+            clear
+        else
+            dpkg-reconfigure tzdata
+        fi
+        # Change timezone in php and logging if the startup script not exists
+        if ! [ -f "$SCRIPTS/nextcloud-startup-script.sh" ]
+        then
+            # Change timezone in PHP
+            sed -i "s|;date.timezone.*|date.timezone = $(cat /etc/timezone)|g" "$PHP_INI"
+
+            # Change timezone for logging
+            occ_command config:system:set logtimezone --value="$(cat /etc/timezone)"
+            clear
+        fi
+    ;;&
+    *)
+    ;;
+esac
+exit

--- a/menu/startup_configuration.sh
+++ b/menu/startup_configuration.sh
@@ -63,7 +63,10 @@ case "$choice" in
             dpkg-reconfigure keyboard-configuration
             setupcon --force
             # Set locales
-            run_script ADDONS locales
+            if ! [ -f "$SCRIPTS/nextcloud-startup-script.sh" ]
+            then
+                run_script ADDONS locales
+            fi
             # test the keyboard settings
             input_box "Please try out all buttons to find out if the keyboard settings were correctly applied.\nIf this isn't the case, you will have the chance to reboot the server in the next step.\n\nPlease continue by hitting [ENTER]" >/dev/null
             if yesno_box_no "Do you want to reboot the server?\nPlease only choose 'Yes' if the keyboard settings weren't correctly applied.\n\nIf you choose 'Yes' and the server is rebooted, please login as usual and run this script again."

--- a/menu/startup_configuration.sh
+++ b/menu/startup_configuration.sh
@@ -46,10 +46,10 @@ else
 fi
 
 # Startup configurations
-choice=$(whiptail --title "$TITLE" --checklist "Choose what you want to change\n$CHECKLIST_GUIDE\n$MENU_GUIDE" "$WT_HEIGHT" "$WT_WIDTH" 4 \
-"Keyboard Layout" "Change the keyboard layout" "$KEYBOARD_LAYOUT_SWITCH" \
-"Locate Mirror" "Change the apt-mirror for faster udpates" "$LOCATE_MIRROR_SWITCH" \
-"Timezone" "Change the timezone" "$TIMEZONE_SWITCH" 3>&1 1>&2 2>&3)
+choice=$(whiptail --title "$TITLE" --checklist "Choose what you want to change\n$CHECKLIST_GUIDE" "$WT_HEIGHT" "$WT_WIDTH" 4 \
+"Keyboard Layout" "(Change the keyboard layout)" "$KEYBOARD_LAYOUT_SWITCH" \
+"Locate Mirror" "(Change the apt-mirror for faster udpates)" "$LOCATE_MIRROR_SWITCH" \
+"Timezone" "(Change the timezone)" "$TIMEZONE_SWITCH" 3>&1 1>&2 2>&3)
 
 case "$choice" in
     *"Keyboard Layout"*)

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -195,9 +195,6 @@ please abort this script (CTRL+C) and report this issue to $ISSUES."
     fi
 fi
 
-# Set locales
-run_script ADDONS locales
-
 ######## The first setup is OK to run to this point several times, but not any further ########
 if [ -f "$SCRIPTS/you-can-not-run-the-startup-script-several-times" ]
 then
@@ -309,6 +306,9 @@ When the setup is done, the server will automatically reboot.
 
 Please report any issues to: $ISSUES"
 clear
+
+# Set locales
+run_script ADDONS locales
 
 # Change timezone in PHP
 sed -i "s|;date.timezone.*|date.timezone = $(cat /etc/timezone)|g" "$PHP_INI"

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -195,6 +195,9 @@ please abort this script (CTRL+C) and report this issue to $ISSUES."
     fi
 fi
 
+# Set locales
+run_script ADDONS locales
+
 ######## The first setup is OK to run to this point several times, but not any further ########
 if [ -f "$SCRIPTS/you-can-not-run-the-startup-script-several-times" ]
 then

--- a/nextcloud-startup-script.sh
+++ b/nextcloud-startup-script.sh
@@ -154,35 +154,14 @@ then
     exit 1
 fi
 
+# Nextcloud 18 is required
+lowest_compatible_nc 18
+
 # Import if missing and export again to import it with UUID
 zpool_import_if_missing
 
-# Set keyboard layout, important when changing passwords and such
-if [ "$KEYBOARD_LAYOUT" = "us" ]
-then
-    clear
-    print_text_in_color "$ICyan" "Current keyboard layout is English (United States)."
-    if ! yesno_box_yes "Do you want to change keyboard layout?"
-    then
-        print_text_in_color "$ICyan" "Not changing keyboard layout..."
-        sleep 1
-        clear
-    else
-        dpkg-reconfigure keyboard-configuration
-        setupcon --force
-        input_box "Please try out all buttons to find out if the keyboard settings were correctly applied.\nIf this isn't the case, you will have the chance to reboot the server in the next step.\n\nPlease continue by hitting [ENTER]" >/dev/null
-        if yesno_box_no "Do you want to reboot the server?\nPlease only choose 'Yes' if the keyboard settings weren't correctly applied.\n\nIf you choose 'Yes' and the server is rebooted, please login as usual and run this script again."
-        then
-            reboot
-        fi
-    fi
-fi
-
-# Set locales
-run_script ADDONS locales
-
-# Nextcloud 18 is required
-lowest_compatible_nc 18
+# Run the startup menu
+run_script MENU startup_configuration
 
 # Is this run as a pure root user?
 if is_root
@@ -215,9 +194,6 @@ please abort this script (CTRL+C) and report this issue to $ISSUES."
         fi
     fi
 fi
-
-# Upgrade mirrors
-run_script ADDONS locate_mirror
 
 ######## The first setup is OK to run to this point several times, but not any further ########
 if [ -f "$SCRIPTS/you-can-not-run-the-startup-script-several-times" ]
@@ -330,17 +306,6 @@ When the setup is done, the server will automatically reboot.
 
 Please report any issues to: $ISSUES"
 clear
-
-# Change Timezone
-print_text_in_color "$ICyan" "Current timezone is $(cat /etc/timezone)"
-if ! yesno_box_yes "Do you want to change the timezone?"
-then
-    print_text_in_color "$ICyan" "Not changing timezone..."
-    sleep 1
-    clear
-else
-    dpkg-reconfigure tzdata
-fi
 
 # Change timezone in PHP
 sed -i "s|;date.timezone.*|date.timezone = $(cat /etc/timezone)|g" "$PHP_INI"


### PR DESCRIPTION
This PR addresses two things:
1. It reorders the items in server_configuration and only enables activate-tls if the file exists
2. I think it is nicer to put all those startup-options into another menu. 
We could then also think about putting this as an additional option into main_menu.

Disclaimer: I haven't tested the complete PR but at least the new menu works in my testing.