### PR TITLE
Don't show a cancel button for input_boxes

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -279,7 +279,7 @@ yesno_box_no() {
 
 input_box() {
     [ -n "$2" ] && local SUBTITLE=" - $2"
-    local RESULT && RESULT=$(whiptail --title "$TITLE$SUBTITLE" --inputbox "$1" "$WT_HEIGHT" "$WT_WIDTH" 3>&1 1>&2 2>&3)
+    local RESULT && RESULT=$(whiptail --title "$TITLE$SUBTITLE" --nocancel --inputbox "$1" "$WT_HEIGHT" "$WT_WIDTH" 3>&1 1>&2 2>&3)
     echo "$RESULT"
 }
 


### PR DESCRIPTION
I think this fixes some confusion that could come up currently if you click on cancel in a input_box and wonder why you cannot cancel with that button