### PR TITLE
change the name of the watchtower container

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -1307,7 +1307,7 @@ fi
 docker_update_specific() {
 if does_this_docker_exist "$1" "$2"
 then
-    docker run --rm --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --cleanup --run-once "$1"
+    docker run --rm --name temporary-watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --cleanup --run-once "$1"
     print_text_in_color "$IGreen" "$2 docker image just got updated!"
     notify_admin_gui "Docker image just got updated!" "We just updated $2 docker image automatically!"
 fi

--- a/lib.sh
+++ b/lib.sh
@@ -1307,7 +1307,7 @@ fi
 docker_update_specific() {
 if does_this_docker_exist "$1" "$2"
 then
-    docker run --rm --name temporary-watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --cleanup --run-once "$1"
+    docker run --rm --name temporary_watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --cleanup --run-once "$1"
     print_text_in_color "$IGreen" "$2 docker image just got updated!"
     notify_admin_gui "Docker image just got updated!" "We just updated $2 docker image automatically!"
 fi


### PR DESCRIPTION
should fix https://github.com/nextcloud/vm/issues/1497

We could alternatively remove watchtower on every instance and not only on instances that have bitwarden installed.
Then the docker run watchtower command should work, too. (Problem is if the watchtower container (with this name) is already present on an instance -> docker cannot create a second one with the same name.