### PR TITLE
improve smbmount to prevent boot-issues

### DIFF
--- a/apps/smbmount.sh
+++ b/apps/smbmount.sh
@@ -98,7 +98,7 @@ do
     if ! grep -q "$SMBSHARES/$count " /etc/fstab
     then 
         # Write to /etc/fstab and mount
-        echo "$SERVER_SHARE_NAME $SMBSHARES/$count cifs credentials=$SMB_CREDENTIALS/SMB$count,uid=www-data,gid=www-data,file_mode=0770,dir_mode=0770,nounix,noserverino,cache=none 0 0" >> /etc/fstab
+        echo "$SERVER_SHARE_NAME $SMBSHARES/$count cifs credentials=$SMB_CREDENTIALS/SMB$count,uid=www-data,gid=www-data,file_mode=0770,dir_mode=0770,nounix,noserverino,cache=none,nofail 0 0" >> /etc/fstab
         mkdir -p $SMB_CREDENTIALS
         touch $SMB_CREDENTIALS/SMB$count
         chown -R root:root $SMB_CREDENTIALS
@@ -611,7 +611,7 @@ then
 fi
 
 # Write changed line to /etc/fstab and mount
-echo "$SERVER_SHARE_NAME $SMBSHARES/$count cifs credentials=$SMB_CREDENTIALS/SMB$count,uid=www-data,gid=www-data,file_mode=0770,dir_mode=0770,nounix,noserverino,cache=none 0 0" >> /etc/fstab
+echo "$SERVER_SHARE_NAME $SMBSHARES/$count cifs credentials=$SMB_CREDENTIALS/SMB$count,uid=www-data,gid=www-data,file_mode=0770,dir_mode=0770,nounix,noserverino,cache=none,nofail 0 0" >> /etc/fstab
 mkdir -p $SMB_CREDENTIALS
 touch "$SMB_CREDENTIALS/SMB$count"
 chown -R root:root $SMB_CREDENTIALS


### PR DESCRIPTION
If the smb-server should somehow not be online, it currently prevents the VM from starting. This fixes this.