### PR TITLE
Make sure that anything that gets reported also gets logged

### DIFF
--- a/addons/smtp-mail.sh
+++ b/addons/smtp-mail.sh
@@ -236,7 +236,7 @@ $(grep -v password /etc/msmtprc)
 Best regards
 The NcVM team
 https://nextcloudvm.com" \
-| mail -s "Test email from your NcVM" "$RECIPIENT" > /var/log/msmtp 2>&1
+| mail -s "Test email from your NcVM" "$RECIPIENT" >> /var/log/msmtp 2>&1
 then
     # Fail message
     msg_box "It seems like something has failed.

--- a/addons/smtp-mail.sh
+++ b/addons/smtp-mail.sh
@@ -236,7 +236,7 @@ $(grep -v password /etc/msmtprc)
 Best regards
 The NcVM team
 https://nextcloudvm.com" \
-| mail -s "Test email from your NcVM" "$RECIPIENT"
+| mail -s "Test email from your NcVM" "$RECIPIENT" > /var/log/msmtp 2>&1
 then
     # Fail message
     msg_box "It seems like something has failed.


### PR DESCRIPTION
Actually I wonder why it still doesn't logg anything because the logging worked also without this hack before.https://help.nextcloud.com/t/nexcloud-vm-smtp-setup-does-not-work/94306/6
But for debugging we want to make sure that anything that gets printed to the command line gets reported there.