### PR TITLE
Update fetch_lib to update the library during the startup script, too

### DIFF
--- a/static/fetch_lib.sh
+++ b/static/fetch_lib.sh
@@ -26,7 +26,7 @@ then
         print_text_in_color "$IRed" "You don't seem to have an internet connection and the local lib isn't available. Hence you cannot run this script."
         exit 1
     fi
-elif ! [ -f /var/scripts/nextcloud-startup-script.sh ]
+elif ! [ -f /var/scripts/nextcloud-startup-script.sh ] || test "$(find /var/scripts/lib.sh -mmin +30)"
 then
     print_text_in_color "$ICyan" "Updating lib..."
     curl -sfL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh -o /var/scripts/lib.sh


### PR DESCRIPTION
This is the best way to solve #1556

But since fetch_lib gets downloaded during the install script, we have no other choice but either don't use fetch_lib for all scripts (only use the online version) that use the new nextcloud_occ commands or revert the change to nextcloud_occ for this release.