### PR TITLE
Adjust whiptail styling to fit Nextcloud a bit better

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -79,6 +79,23 @@ TITLE="Nextcloud VM - $(date +%Y)"
 CHECKLIST_GUIDE="Navigate with the [ARROW] keys and (de)select with the [SPACE] key. Confirm by pressing [ENTER]"
 MENU_GUIDE="Navigate with the [ARROW] keys and confirm by pressing [ENTER]"
 RUN_LATER_GUIDE="You can view this script later by running 'sudo bash $SCRIPTS/menu.sh'"
+# Whiptail styling:
+export NEWT_COLORS='
+root=brightblue,brightblue
+window=white,white
+border=blue,white
+shadow=blue,blue
+title=blue,white
+textbox=black,white
+button=white,brightblue
+compactbutton=black,white
+listbox=black,white
+actlistbox=white,brightblue
+actsellistbox=white,brightblue
+checkbox=black,white
+actcheckbox=white,brightblue
+entry=white,brightblue
+'
 # Repo
 GITHUB_REPO="https://raw.githubusercontent.com/nextcloud/vm/master"
 STATIC="$GITHUB_REPO/static"


### PR DESCRIPTION
It is based on this:
https://askubuntu.com/questions/776831/whiptail-change-background-color-dynamically-from-magenta

This is how it looks like now:
![image](https://user-images.githubusercontent.com/42591237/96196479-bea13100-0f4f-11eb-83f3-4992eda0b58c.png)
![image](https://user-images.githubusercontent.com/42591237/96196496-c7920280-0f4f-11eb-93c7-e366ffd2f062.png)
![image](https://user-images.githubusercontent.com/42591237/96196509-d1b40100-0f4f-11eb-8071-29550e766f2f.png)
![image](https://user-images.githubusercontent.com/42591237/96196521-de385980-0f4f-11eb-8da9-ce94d6a549f3.png)