### PR TITLE
fix some issues with smtp-mail

### DIFF
--- a/addons/smtp-mail.sh
+++ b/addons/smtp-mail.sh
@@ -162,12 +162,12 @@ tls_trust_file  /etc/ssl/certs/ca-certificates.crt
 # logfile         /var/log/msmtp
 
 # Account to send emails
-account         $MAIL_SERVER
+account         $MAIL_USERNAME
 host            $MAIL_SERVER
 port            $SMTP_PORT
 from            $MAIL_USERNAME
 
-account default : $MAIL_SERVER
+account default : $MAIL_USERNAME
 
 ### DO NOT REMOVE THIS LINE (it's used in one of the functions in on the Nextcloud Server)
 # recipient=$RECIPIENT
@@ -186,14 +186,14 @@ tls_trust_file  /etc/ssl/certs/ca-certificates.crt
 logfile         /var/log/msmtp
 
 # Account to send emails
-account         $MAIL_SERVER
+account         $MAIL_USERNAME
 host            $MAIL_SERVER
 port            $SMTP_PORT
 from            $MAIL_USERNAME
 user            $MAIL_USERNAME
 password        $MAIL_PASSWORD
 
-account default : $MAIL_SERVER
+account default : $MAIL_USERNAME
 
 ### DO NOT REMOVE THIS LINE (it's used in one of the functions in on the Nextcloud Server)
 # recipient=$RECIPIENT


### PR DESCRIPTION
While debugging #1563 I discovered this issue.

As I said this was my guide:
https://decatec.de/linux/linux-einfach-e-mails-versenden-mit-msmtp/
And there you can see that those values (account and account default) definitely should be the mail_username.
I've tested this successfully with my account.