### PR TITLE
restore msg_box for bitwarden_rs

### DIFF
--- a/apps/bitwarden-rs.sh
+++ b/apps/bitwarden-rs.sh
@@ -19,6 +19,9 @@ debug_mode
 # Check if root
 root_check
 
+# Show explainer
+msg_box "$SCRIPT_EXPLAINER"
+
 # Check if bitwarden_rs is already installed
 if [ -d /home/bitwarden_rs ] || docker ps -a --format '{{.Names}}' | grep -Eq "bitwarden_rs";
 then


### PR DESCRIPTION
Bitwarden RS doesn't have an install_popup so it needs the msg_box.
Sry, I've overlooked this.
The other are correct, though.