### PR TITLE
Fix mail subject switch

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -1531,7 +1531,7 @@ send_mail() {
         if [ -n "$RECIPIENT" ]
         then
             print_text_in_color "$ICyan" "Sending '$1' to $RECIPIENT"
-            if echo -e "$2" | mail --subject "NcVM - $1" "$RECIPIENT"
+            if echo -e "$2" | mail -s "NcVM - $1" "$RECIPIENT"
             then
                 return 0
             fi


### PR DESCRIPTION
As per issue #1687 I'm not sure how the Ubuntu mail command with `mail --subject` has worked.
All documentation I can find on the mail utility shows `-s` as the valid switch to set a subject, not a `--` switch.

The reason the welcome email works is it already uses `-s` [in the script](https://github.com/nextcloud/vm/blob/master/addons/smtp-mail.sh#L235) `smtp-mail.sh`