### PR TITLE
Fix README typo deps->kernel->version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Server installation. Simplified. :cloud:
 ## Dependencies:
 (Ubuntu Server 20.04 LTS 64-bit)
 <br>
-(Linux Kernel: 5.14)
+(Linux Kernel: 5.4)
 - Apache 2.4
 - PostgreSQL 12
 - PHP-FPM 7.4


### PR DESCRIPTION
Ubuntu Server 20.04 ships with kernel 5.4.
(as of 2020.12 there isn't yet a 5.14 kernel)