### PR TITLE
fix a detail with the new app restore process

### DIFF
--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -790,10 +790,18 @@ then
                     install_and_enable_app "$app"
                 # If the app is missing from the apps folder and was installed but not enabled before the upgrade was done, 
                 # then reinstall it but keep it disabled
-                elif [ "${APPSTORAGE[$app]}" != "yes" ]
+                elif [ "${APPSTORAGE[$app]}" = "no" ]
                 then
                     install_and_enable_app "$app"
                     nextcloud_occ_no_check app:disable "$app"
+                # Cover the case where the app is enabled for certain groups
+                else
+                    install_and_enable_app "$app"
+                    if is_app_enabled "$app"
+                    then
+                        # Only restore the group settings, if the app was enabled (and is thus compatible with the new NC version)
+                        nextcloud_occ_no_check config:app:set "$app" enabled --value="${APPSTORAGE[$app]}"
+                    fi
                 fi
             fi
             # If the app still isn't enabled (maybe because it's incompatible), then at least restore from backup,

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -784,7 +784,12 @@ then
         fi
         if [ -n "${APPSTORAGE[$app]}" ] && [ "${APPSTORAGE[$app]}" != "yes" ] && is_app_enabled "$app"
         then
-            nextcloud_occ_no_check config:app:set "$app" enabled --value="${APPSTORAGE[$app]}"
+            if [ "${APPSTORAGE[$app]}" = "no" ]
+            then
+                nextcloud_occ_no_check app:disable "$app"
+            else
+                nextcloud_occ_no_check config:app:set "$app" enabled --value="${APPSTORAGE[$app]}"
+            fi
         fi
     done
 fi

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -780,11 +780,16 @@ then
     do
         if [ -n "${APPSTORAGE[$app]}" ]
         then
+            # Check if the app is in Nextclouds app storage
             if ! [ -d "$NC_APPS_PATH/$app" ]
             then
+                # If the app is missing from the apps folder and was installed and enabled before the upgrade was done,
+                # then reinstall it
                 if [ "${APPSTORAGE[$app]}" = "yes" ]
                 then
                     install_and_enable_app "$app"
+                # If the app is missing from the apps folder and was installed but not enabled before the upgrade was done, 
+                # then reinstall it but keep it disabled
                 elif [ "${APPSTORAGE[$app]}" != "yes" ]
                 then
                     install_and_enable_app "$app"

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -796,6 +796,15 @@ then
                     nextcloud_occ_no_check app:disable "$app"
                 fi
             fi
+            # If the app still isn't enabled (maybe because it's incompatible), then at least restore from backup,
+            # and make sure it's disabled
+            if ! [ -d "$NC_APPS_PATH/$app" ] && [ -d "$BACKUP/apps/$app" ]
+            then
+                print_text_in_color "$ICyan" "Restoring $app from $BACKUP/apps..."
+                rsync -Aaxz "$BACKUP/apps/$app" "$NC_APPS_PATH/"
+                bash "$SECURE"
+                nextcloud_occ_no_check app:disable "$app"
+            fi
         fi
     done
 fi

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -780,23 +780,15 @@ then
     do
         if [ -n "${APPSTORAGE[$app]}" ]
         then
-            # Check if the app is in Nextclouds app storage
             if ! [ -d "$NC_APPS_PATH/$app" ]
             then
-                # If the app is missing from the apps folder and was installed and enabled before the upgrade was done,
-                # then reinstall it
                 if [ "${APPSTORAGE[$app]}" = "yes" ]
                 then
                     install_and_enable_app "$app"
-                # If the app is missing from the apps folder and was installed but not enabled before the upgrade was done, 
-                # then reinstall it but keep it disabled
                 elif [ "${APPSTORAGE[$app]}" != "yes" ]
                 then
-                    if ! is_app_installed "$app"
-                    then
-                        nextcloud_occ_no_check app:install "$app"
-                        nextcloud_occ_no_check app:disable "$app"
-                    fi
+                    install_and_enable_app "$app"
+                    nextcloud_occ_no_check app:disable "$app"
                 fi
             fi
         fi


### PR DESCRIPTION
Sry for not integrating that earlier but as I found out, the app:disable command actually does more than just setting the database entry for that app to no: https://github.com/nextcloud/server/blob/f124cb0ef11fa15f21217552bedc6dd4a8ff9b5d/lib/private/App/AppManager.php#L397-L419
So I guess it is better to use the official command in that case.
Follow up to #1811

Signed-off-by: szaimen <szaimen@e.mail.de>