### PR TITLE
geoblock - allow some scans

### DIFF
--- a/network/geoblock.sh
+++ b/network/geoblock.sh
@@ -181,6 +181,9 @@ GEOIP_CONF+="  Allow from env=AllowCountryOrContinent
   Allow from 192.168.0.0/16
   Allow from 172.16.0.0/12
   Allow from 10.0.0.0/8
+  Allow from scan.nextcloud.com
+  # Allow scans from observatory.mozilla.org:
+  Allow from 63.245.208.0/24
   Order Deny,Allow
   Deny from all
 </Location>


### PR DESCRIPTION
Allow scans from scan.nextcloud.com and observatory.mozilla.org
(63.245.208.0/24) are all owned by mozilla based on https://www.lookip.net/
fixes https://help.nextcloud.com/t/nextcloud-security-scan-no-error-but-scan-not-updating/103503/9
Signed-off-by: szaimen <szaimen@e.mail.de>