### PR TITLE
switch to beta release channel if new major version was found

### DIFF
--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -870,6 +870,7 @@ To recover your old apps, please check $BACKUP/apps and copy them to $NCPATH/app
 Thank you for using T&M Hansson IT's updater!"
     nextcloud_occ status
     nextcloud_occ maintenance:mode --off
+    nextcloud_occ config:system:set updater.release.channel --value="stable"
     print_text_in_color "$ICyan" "Sending notification about the successful update to all admins..."
     notify_admin_gui \
     "Nextcloud is now updated!" \

--- a/static/updatenotification.sh
+++ b/static/updatenotification.sh
@@ -78,6 +78,7 @@ fi
 if version_gt "$NCVERSION" "$REPORTEDMAJ" && version_gt "$NCVERSION" "$CURRENTVERSION"
 then
     sed -i "s|^REPORTEDMAJ.*|REPORTEDMAJ=$NCVERSION|" $SCRIPTS/updatenotification.sh
+    nextcloud_occ config:system:set updater.release.channel --value="beta"
     notify_admin_gui \
     "New major Nextcloud Update!" \
     "Nextcloud $NCVERSION just became available. Please run 'sudo bash \


### PR DESCRIPTION
I think this makes sense since most of the time you won't see the new major update in https://your-nc-domain/settings/admin/overview unless you set it to the beta channel.
And as you know, this is no problem since the update script doesn't rely on this channel either way.
Signed-off-by: szaimen <szaimen@e.mail.de>