### PR TITLE
fix pecl php extensions

### DIFF
--- a/addons/redis-server-ubuntu.sh
+++ b/addons/redis-server-ubuntu.sh
@@ -56,10 +56,6 @@ then
 fi
 install_if_not redis-server
 
-# Setting direct to PHP-FPM as it's installed with PECL (globally doesn't work)
-print_text_in_color "$ICyan" "Adding extension=redis.so to $PHP_INI..."
-echo 'extension=redis.so' >> "$PHP_INI"
-
 # Prepare for adding redis configuration
 sed -i "s|);||g" $NCPATH/config/config.php
 

--- a/addons/redis-server-ubuntu.sh
+++ b/addons/redis-server-ubuntu.sh
@@ -44,6 +44,16 @@ exit 1
 else
     printf "${IGreen}\nPHP module installation OK!${Color_Off}\n"
 fi
+if [ ! -f $PHP_MODS_DIR/redis.ini ]
+then
+    touch $PHP_MODS_DIR/redis.ini
+fi
+if ! grep -qFx extension=redis.so $PHP_MODS_DIR/redis.ini
+then
+    echo "# PECL redis" > $PHP_MODS_DIR/redis.ini
+    echo "extension=redis.so" >> $PHP_MODS_DIR/redis.ini
+    check_command phpenmod -v ALL redis
+fi
 install_if_not redis-server
 
 # Setting direct to PHP-FPM as it's installed with PECL (globally doesn't work)

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -606,7 +606,6 @@ then
     fi
 {
 echo "# igbinary for PHP"
-echo "extension=igbinary.so"
 echo "session.serialize_handler=igbinary"
 echo "igbinary.compact_strings=On"
 } >> "$PHP_INI"
@@ -635,7 +634,6 @@ then
     fi
 {
 echo "# APCu settings for Nextcloud"
-echo "extension=apcu.so"
 echo "apc.enabled=1"
 echo "apc.max_file_size=5M"
 echo "apc.shm_segments=1"

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -610,6 +610,16 @@ echo "extension=igbinary.so"
 echo "session.serialize_handler=igbinary"
 echo "igbinary.compact_strings=On"
 } >> "$PHP_INI"
+if [ ! -f $PHP_MODS_DIR/igbinary.ini ]
+then
+    touch $PHP_MODS_DIR/igbinary.ini
+fi
+if ! grep -qFx extension=igbinary.so $PHP_MODS_DIR/igbinary.ini
+then
+    echo "# PECL igbinary" > $PHP_MODS_DIR/igbinary.ini
+    echo "extension=igbinary.so" >> $PHP_MODS_DIR/igbinary.ini
+    check_command phpenmod -v ALL igbinary
+fi
 restart_webserver
 fi
 
@@ -641,6 +651,16 @@ echo "apc.serializer=igbinary"
 echo "apc.coredump_unmap=0"
 echo "apc.preload_path"
 } >> "$PHP_INI"
+if [ ! -f $PHP_MODS_DIR/apcu.ini ]
+then
+    touch $PHP_MODS_DIR/apcu.ini
+fi
+if ! grep -qFx extension=apcu.so $PHP_MODS_DIR/apcu.ini
+then
+    echo "# PECL apcu" > $PHP_MODS_DIR/apcu.ini
+    echo "extension=apcu.so" >> $PHP_MODS_DIR/apcu.ini
+    check_command phpenmod -v ALL apcu
+fi
 restart_webserver
 fi
 

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -264,7 +264,7 @@ fi
 # Remove old redis
 if grep -qFx extension=redis.so "$PHP_INI"
 then
-    sed -i "s|extension=redis.so||g" "$PHP_INI"
+    sed -i "/extension=redis.so/d" "$PHP_INI"
 fi
 # Check if redis is enabled and create the file if not
 if [ ! -f $PHP_MODS_DIR/redis.ini ]
@@ -291,7 +291,7 @@ then
             # Remove old igbinary
             if grep -qFx extension=igbinary.so "$PHP_INI"
             then
-                sed -i "s|extension=igbinary.so||g" "$PHP_INI"
+                sed -i "/extension=igbinary.so/d" "$PHP_INI"
             fi
             # Check if igbinary is enabled and create the file if not
             if [ ! -f $PHP_MODS_DIR/igbinary.ini ]
@@ -324,7 +324,7 @@ then
             # Remove old smbclient
             if grep -qFx extension=smbclient.so "$PHP_INI"
             then
-                sed -i "s|extension=smbclient.so||g" "$PHP_INI"
+                sed -i "/extension=smbclient.so/d" "$PHP_INI"
             fi
         fi
         if pecl list | grep -q apcu
@@ -333,7 +333,7 @@ then
             # Remove old igbinary
             if grep -qFx extension=apcu.so "$PHP_INI"
             then
-                sed -i "s|extension=apcu.so||g" "$PHP_INI"
+                sed -i "/extension=apcu.so/d" "$PHP_INI"
             fi
             # Check if apcu is enabled and create the file if not
             if [ ! -f $PHP_MODS_DIR/apcu.ini ]
@@ -353,7 +353,7 @@ then
             # Remove old inotify
             if grep -qFx extension=inotify.so "$PHP_INI"
             then
-                sed -i "s|extension=inotify.so||g" "$PHP_INI"
+                sed -i "/extension=inotify.so/d" "$PHP_INI"
             fi
             yes no | pecl upgrade inotify
             if [ ! -f $PHP_MODS_DIR/inotify.ini ]

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -261,11 +261,10 @@ then
     yes no | pecl upgrade redis
     systemctl restart redis-server.service
 fi
-
-# Double check if redis.so is enabled
-if ! grep -qFx extension=redis.so "$PHP_INI"
+# Remove old redis
+if grep -qFx extension=redis.so "$PHP_INI"
 then
-    echo "extension=redis.so" >> "$PHP_INI"
+    sed -i "s|extension=redis.so||g" "$PHP_INI"
 fi
 # Check if redis is enabled and create the file if not
 if [ ! -f $PHP_MODS_DIR/redis.ini ]

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -289,10 +289,10 @@ then
         if pecl list | grep igbinary >/dev/null 2>&1
         then
             yes no | pecl upgrade igbinary
-            # Check if igbinary.so is enabled
-            if ! grep -qFx extension=igbinary.so "$PHP_INI"
+            # Remove old igbinary
+            if grep -qFx extension=igbinary.so "$PHP_INI"
             then
-                echo "extension=igbinary.so" >> "$PHP_INI"
+                sed -i "s|extension=igbinary.so||g" "$PHP_INI"
             fi
             # Check if igbinary is enabled and create the file if not
             if [ ! -f $PHP_MODS_DIR/igbinary.ini ]
@@ -331,10 +331,10 @@ then
         if pecl list | grep -q apcu
         then
             yes no | pecl upgrade apcu
-            # Check if apcu.so is enabled
-            if ! grep -qFx extension=apcu.so "$PHP_INI"
+            # Remove old igbinary
+            if grep -qFx extension=apcu.so "$PHP_INI"
             then
-                echo "extension=apcu.so" >> "$PHP_INI"
+                sed -i "s|extension=apcu.so||g" "$PHP_INI"
             fi
             # Check if apcu is enabled and create the file if not
             if [ ! -f $PHP_MODS_DIR/apcu.ini ]
@@ -351,11 +351,21 @@ then
         fi
         if pecl list | grep -q inotify
         then 
-            yes no | pecl upgrade inotify
-            # Check if inotify.so is enabled
-            if ! grep -qFx extension=inotify.so "$PHP_INI"
+            # Remove old inotify
+            if grep -qFx extension=inotify.so "$PHP_INI"
             then
-                echo "extension=inotify.so" >> "$PHP_INI"
+                sed -i "s|extension=inotify.so||g" "$PHP_INI"
+            fi
+            yes no | pecl upgrade inotify
+            if [ ! -f $PHP_MODS_DIR/inotify.ini ]
+            then
+                touch $PHP_MODS_DIR/inotify.ini
+            fi
+            if ! grep -qFx extension=inotify.so $PHP_MODS_DIR/inotify.ini
+            then
+                echo "# PECL inotify" > $PHP_MODS_DIR/inotify.ini
+                echo "extension=inotify.so" >> $PHP_MODS_DIR/inotify.ini
+                check_command phpenmod -v ALL inotify
             fi
         fi
     fi

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -267,6 +267,18 @@ if ! grep -qFx extension=redis.so "$PHP_INI"
 then
     echo "extension=redis.so" >> "$PHP_INI"
 fi
+# Check if redis is enabled and create the file if not
+if [ ! -f $PHP_MODS_DIR/redis.ini ]
+then
+    touch $PHP_MODS_DIR/redis.ini
+fi
+# Enable new redis
+if ! grep -qFx extension=redis.so $PHP_MODS_DIR/redis.ini
+then
+    echo "# PECL redis" > $PHP_MODS_DIR/redis.ini
+    echo "extension=redis.so" >> $PHP_MODS_DIR/redis.ini
+    check_command phpenmod -v ALL redis
+fi
 
 # Upgrade APCu and igbinary
 if [ "${CURRENTVERSION%%.*}" -ge "17" ]
@@ -281,6 +293,18 @@ then
             if ! grep -qFx extension=igbinary.so "$PHP_INI"
             then
                 echo "extension=igbinary.so" >> "$PHP_INI"
+            fi
+            # Check if igbinary is enabled and create the file if not
+            if [ ! -f $PHP_MODS_DIR/igbinary.ini ]
+            then
+                touch $PHP_MODS_DIR/igbinary.ini
+            fi
+            # Enable new igbinary
+            if ! grep -qFx extension=igbinary.so $PHP_MODS_DIR/igbinary.ini
+            then
+                echo "# PECL igbinary" > $PHP_MODS_DIR/igbinary.ini
+                echo "extension=igbinary.so" >> $PHP_MODS_DIR/igbinary.ini
+                check_command phpenmod -v ALL igbinary
             fi
         fi
         if pecl list | grep -q smbclient
@@ -311,6 +335,18 @@ then
             if ! grep -qFx extension=apcu.so "$PHP_INI"
             then
                 echo "extension=apcu.so" >> "$PHP_INI"
+            fi
+            # Check if apcu is enabled and create the file if not
+            if [ ! -f $PHP_MODS_DIR/apcu.ini ]
+            then
+                touch $PHP_MODS_DIR/apcu.ini
+            fi
+            # Enable new apcu
+            if ! grep -qFx extension=apcu.so $PHP_MODS_DIR/apcu.ini
+            then
+                echo "# PECL apcu" > $PHP_MODS_DIR/apcu.ini
+                echo "extension=apcu.so" >> $PHP_MODS_DIR/apcu.ini
+                check_command phpenmod -v ALL apcu
             fi
         fi
         if pecl list | grep -q inotify


### PR DESCRIPTION
while testing #1817 I found out that all php extensions that are installed via pecl except smbclient weren't enabled when listing them via `php -m`. This fixes this.
Signed-off-by: szaimen <szaimen@e.mail.de>