### PR TITLE
Revert "fix pecl php extensions"

### DIFF
--- a/addons/redis-server-ubuntu.sh
+++ b/addons/redis-server-ubuntu.sh
@@ -44,17 +44,11 @@ exit 1
 else
     printf "${IGreen}\nPHP module installation OK!${Color_Off}\n"
 fi
-if [ ! -f $PHP_MODS_DIR/redis.ini ]
-then
-    touch $PHP_MODS_DIR/redis.ini
-fi
-if ! grep -qFx extension=redis.so $PHP_MODS_DIR/redis.ini
-then
-    echo "# PECL redis" > $PHP_MODS_DIR/redis.ini
-    echo "extension=redis.so" >> $PHP_MODS_DIR/redis.ini
-    check_command phpenmod -v ALL redis
-fi
 install_if_not redis-server
+
+# Setting direct to PHP-FPM as it's installed with PECL (globally doesn't work)
+print_text_in_color "$ICyan" "Adding extension=redis.so to $PHP_INI..."
+echo 'extension=redis.so' >> "$PHP_INI"
 
 # Prepare for adding redis configuration
 sed -i "s|);||g" $NCPATH/config/config.php

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -606,19 +606,10 @@ then
     fi
 {
 echo "# igbinary for PHP"
+echo "extension=igbinary.so"
 echo "session.serialize_handler=igbinary"
 echo "igbinary.compact_strings=On"
 } >> "$PHP_INI"
-if [ ! -f $PHP_MODS_DIR/igbinary.ini ]
-then
-    touch $PHP_MODS_DIR/igbinary.ini
-fi
-if ! grep -qFx extension=igbinary.so $PHP_MODS_DIR/igbinary.ini
-then
-    echo "# PECL igbinary" > $PHP_MODS_DIR/igbinary.ini
-    echo "extension=igbinary.so" >> $PHP_MODS_DIR/igbinary.ini
-    check_command phpenmod -v ALL igbinary
-fi
 restart_webserver
 fi
 
@@ -634,6 +625,7 @@ then
     fi
 {
 echo "# APCu settings for Nextcloud"
+echo "extension=apcu.so"
 echo "apc.enabled=1"
 echo "apc.max_file_size=5M"
 echo "apc.shm_segments=1"
@@ -649,16 +641,6 @@ echo "apc.serializer=igbinary"
 echo "apc.coredump_unmap=0"
 echo "apc.preload_path"
 } >> "$PHP_INI"
-if [ ! -f $PHP_MODS_DIR/apcu.ini ]
-then
-    touch $PHP_MODS_DIR/apcu.ini
-fi
-if ! grep -qFx extension=apcu.so $PHP_MODS_DIR/apcu.ini
-then
-    echo "# PECL apcu" > $PHP_MODS_DIR/apcu.ini
-    echo "extension=apcu.so" >> $PHP_MODS_DIR/apcu.ini
-    check_command phpenmod -v ALL apcu
-fi
 restart_webserver
 fi
 

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -261,22 +261,11 @@ then
     yes no | pecl upgrade redis
     systemctl restart redis-server.service
 fi
-# Remove old redis
-if grep -qFx extension=redis.so "$PHP_INI"
+
+# Double check if redis.so is enabled
+if ! grep -qFx extension=redis.so "$PHP_INI"
 then
-    sed -i "/extension=redis.so/d" "$PHP_INI"
-fi
-# Check if redis is enabled and create the file if not
-if [ ! -f $PHP_MODS_DIR/redis.ini ]
-then
-    touch $PHP_MODS_DIR/redis.ini
-fi
-# Enable new redis
-if ! grep -qFx extension=redis.so $PHP_MODS_DIR/redis.ini
-then
-    echo "# PECL redis" > $PHP_MODS_DIR/redis.ini
-    echo "extension=redis.so" >> $PHP_MODS_DIR/redis.ini
-    check_command phpenmod -v ALL redis
+    echo "extension=redis.so" >> "$PHP_INI"
 fi
 
 # Upgrade APCu and igbinary
@@ -288,22 +277,10 @@ then
         if pecl list | grep igbinary >/dev/null 2>&1
         then
             yes no | pecl upgrade igbinary
-            # Remove old igbinary
-            if grep -qFx extension=igbinary.so "$PHP_INI"
+            # Check if igbinary.so is enabled
+            if ! grep -qFx extension=igbinary.so "$PHP_INI"
             then
-                sed -i "/extension=igbinary.so/d" "$PHP_INI"
-            fi
-            # Check if igbinary is enabled and create the file if not
-            if [ ! -f $PHP_MODS_DIR/igbinary.ini ]
-            then
-                touch $PHP_MODS_DIR/igbinary.ini
-            fi
-            # Enable new igbinary
-            if ! grep -qFx extension=igbinary.so $PHP_MODS_DIR/igbinary.ini
-            then
-                echo "# PECL igbinary" > $PHP_MODS_DIR/igbinary.ini
-                echo "extension=igbinary.so" >> $PHP_MODS_DIR/igbinary.ini
-                check_command phpenmod -v ALL igbinary
+                echo "extension=igbinary.so" >> "$PHP_INI"
             fi
         fi
         if pecl list | grep -q smbclient
@@ -324,47 +301,25 @@ then
             # Remove old smbclient
             if grep -qFx extension=smbclient.so "$PHP_INI"
             then
-                sed -i "/extension=smbclient.so/d" "$PHP_INI"
+                sed -i "s|extension=smbclient.so||g" "$PHP_INI"
             fi
         fi
         if pecl list | grep -q apcu
         then
             yes no | pecl upgrade apcu
-            # Remove old igbinary
-            if grep -qFx extension=apcu.so "$PHP_INI"
+            # Check if apcu.so is enabled
+            if ! grep -qFx extension=apcu.so "$PHP_INI"
             then
-                sed -i "/extension=apcu.so/d" "$PHP_INI"
-            fi
-            # Check if apcu is enabled and create the file if not
-            if [ ! -f $PHP_MODS_DIR/apcu.ini ]
-            then
-                touch $PHP_MODS_DIR/apcu.ini
-            fi
-            # Enable new apcu
-            if ! grep -qFx extension=apcu.so $PHP_MODS_DIR/apcu.ini
-            then
-                echo "# PECL apcu" > $PHP_MODS_DIR/apcu.ini
-                echo "extension=apcu.so" >> $PHP_MODS_DIR/apcu.ini
-                check_command phpenmod -v ALL apcu
+                echo "extension=apcu.so" >> "$PHP_INI"
             fi
         fi
         if pecl list | grep -q inotify
         then 
-            # Remove old inotify
-            if grep -qFx extension=inotify.so "$PHP_INI"
-            then
-                sed -i "/extension=inotify.so/d" "$PHP_INI"
-            fi
             yes no | pecl upgrade inotify
-            if [ ! -f $PHP_MODS_DIR/inotify.ini ]
+            # Check if inotify.so is enabled
+            if ! grep -qFx extension=inotify.so "$PHP_INI"
             then
-                touch $PHP_MODS_DIR/inotify.ini
-            fi
-            if ! grep -qFx extension=inotify.so $PHP_MODS_DIR/inotify.ini
-            then
-                echo "# PECL inotify" > $PHP_MODS_DIR/inotify.ini
-                echo "extension=inotify.so" >> $PHP_MODS_DIR/inotify.ini
-                check_command phpenmod -v ALL inotify
+                echo "extension=inotify.so" >> "$PHP_INI"
             fi
         fi
     fi


### PR DESCRIPTION
Reverts nextcloud/vm#1825

ouch: cannot touch '/etc/php/7.4/mods-available/igbinary.ini': No such file or directory
grep: /etc/php/7.4/mods-available/igbinary.ini: No such file or directory
/var/scripts/nextcloud_update.sh: line 304: /etc/php/7.4/mods-available/igbinary.ini: No such file or directory
/var/scripts/nextcloud_update.sh: line 305: /etc/php/7.4/mods-available/igbinary.ini: No such file or directory
WARNING: Module igbinary ini file doesn't exist under /etc/php/7.2/mods-available
WARNING: Module igbinary ini file doesn't exist under /etc/php/7.2/mods-available
Nothing to upgrade
touch: cannot touch '/etc/php/7.4/mods-available/apcu.ini': No such file or directory
grep: /etc/php/7.4/mods-available/apcu.ini: No such file or directory
/var/scripts/nextcloud_update.sh: line 346: /etc/php/7.4/mods-available/apcu.ini: No such file or directory
/var/scripts/nextcloud_update.sh: line 347: /etc/php/7.4/mods-available/apcu.ini: No such file or directory
WARNING: Module apcu ini file doesn't exist under /etc/php/7.2/mods-available
WARNING: Module apcu ini file doesn't exist under /etc/php/7.2/mods-available
Reading package lists... Done
