### PR TITLE
set max_chunk_size by default to 100MB

### DIFF
--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -534,7 +534,7 @@ nextcloud_occ config:system:set versions_retention_obligation --value="auto, 180
 nextcloud_occ config:system:set simpleSignUpLink.shown --type=bool --value=false
 
 # Set chunk_size for files app to 100MB (defaults to 10MB)
-nextcloud_occ config:app:set files max_chunk_size --value="1048576000"
+nextcloud_occ config:app:set files max_chunk_size --value="104857600"
 
 # Enable OPCache for PHP
 # https://docs.nextcloud.com/server/14/admin_manual/configuration_server/server_tuning.html#enable-php-opcache

--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -533,6 +533,9 @@ nextcloud_occ config:system:set versions_retention_obligation --value="auto, 180
 # Remove simple signup
 nextcloud_occ config:system:set simpleSignUpLink.shown --type=bool --value=false
 
+# Set chunk_size for files app to 100MB (defaults to 10MB)
+nextcloud_occ config:app:set files max_chunk_size --value="1048576000"
+
 # Enable OPCache for PHP
 # https://docs.nextcloud.com/server/14/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
 phpenmod opcache


### PR DESCRIPTION
This incredibly speeds up the transfer of big files via the web-interface. I for myself did set it to 1000MB.
Signed-off-by: szaimen <szaimen@e.mail.de>