### PR TITLE
merge on release day

### DIFF
--- a/apps/talk.sh
+++ b/apps/talk.sh
@@ -97,26 +97,6 @@ do
         # Ask for port
         TURN_PORT=$(input_box_flow "Please enter the port you will use for Nextcloud Talk")
     fi
-    
-########## TEMPORARY
-NONO_PORTS=(22 25 53 80 443 1024 3012 3306 5178 5179 5432 7867 7983 8983 10000 8081 8443 9443)
-test_nono_ports() {
-  local e match="$1"
-  shift
-  for e; do [[ "$e" == "$match" ]] && return 0; done
-  return 1
-}
-
-check_nono_ports() {
-if test_nono_ports "${1}" "${NONO_PORTS[@]}"
-then
-    msg_box "You have to choose another port than $1. Please start over.\n
-Please keep in mind NOT to use the following ports as they are likely in use already: 
-${NONO_PORTS[*]}"
-    return 1
-fi
-}
-########## TEMPORARY
 
     # Check if port is taken and exit if that's the case
     if check_nono_ports "$TURN_PORT"

--- a/lets-encrypt/activate-tls.sh
+++ b/lets-encrypt/activate-tls.sh
@@ -240,8 +240,8 @@ ${NONO_PORTS[*]}"
                 DEDYNPORT=$(input_box_flow "Please choose which port you want between 1024 - 49151.\n\nPlease remember to open this port in your firewall.")
                 if (("$DEDYNPORT" >= 1024 && "$DEDYNPORT" <= 49151))
                 then
-                    #if check_nono_ports "$DEDYNPORT"
-                    #then
+                    if check_nono_ports "$DEDYNPORT"
+                    then
                         print_text_in_color "$ICyan" "Changing to port $DEDYNPORT for public access..."
                         # Main port
                         sed -i "s|VirtualHost \*:443|VirtualHost \*:$DEDYNPORT|g" "$tls_conf"
@@ -261,7 +261,7 @@ ${NONO_PORTS[*]}"
                             msg_box "Congrats! You should now be able to access Nextcloud publicly on: https://$TLSDOMAIN:$DEDYNPORT, after you opened port $DEDYNPORT in your firewall."
                             break
                         fi
-                    #fi
+                    fi
                 else
                     msg_box "The port number needs to be between 1024 - 49151, please try again."
                 fi


### PR DESCRIPTION
NONO ports was moved outside of `turn_server` and since the lib in the released VM is old, it doesn't work without this temporary fix.

Remove the temporary fixes on release day.