### PR TITLE
Make it possible to add subdomains to deSEC

### DIFF
--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -1,6 +1,6 @@
 source /var/scripts/fetch_lib.sh
 
-if [ -f "$SCRIPTS"/deSEC/.dedynauth ] && [ -f [ /etc/ddclient.conf ]
+if [ -f "$SCRIPTS"/deSEC/.dedynauth ] && [ -f /etc/ddclient.conf ]
 then
     DEDYN_TOKEN=$(grep DEDYN_TOKEN "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
     DEDYN_NAME=$(grep DEDYN_NAME "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -73,7 +73,7 @@ curl https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/"$SUBDOMAIN"/A/ \
 ####################
 
 # Check the subdomain exist within the domain
-if check_desec_subdomain | grep -Po "Not found"
+if check_desec_subdomain | grep -qPo "Not found"
 then
     # Ask for installing
     install_popup "$SCRIPT_NAME"
@@ -83,10 +83,10 @@ else
     # Delete the subdomain, but wait for throttling if it's there
     while :
     do
-        if delete_desec_subdomain | grep -Po "throttled"
+        if delete_desec_subdomain | grep -qPo "throttled"
         then
             print_text_in_color "$IRed" "Still throttling..."
-            msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to delete $SUBDOMAIN(.$DEDYN_NAME)..."
+            msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to delete $SUBDOMAIN.$DEDYN_NAME..."
             countdown "Waiting for throttling to end, please wait for the script to continue..." "600"
             delete_desec_subdomain
         else
@@ -105,10 +105,10 @@ fi
 # Add the subdomain, but wait for throttling if it's there
 while :
 do
-    if add_desec_subdomain | grep -Po "throttled"
+    if add_desec_subdomain | grep -qPo "throttled"
     then
         print_text_in_color "$IRed" "Still throttling..."
-        msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to add $SUBDOMAIN(.$DEDYN_NAME)..."
+        msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to add $SUBDOMAIN.$DEDYN_NAME..."
         countdown "Waiting for throttling to end, please wait for the script to continue..." "600"
         add_desec_subdomain
     else

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -36,6 +36,12 @@ fi
 
 SUBDOMAIN=$(input_box_flow "Please enter the subdomain you want to add or delete, e.g: yoursubdomain")
 
+print_text_in_color "$ICyan" "Checking current WAN address (IPv4)..."
+if [ -z "$WANIP4" ]
+then
+    WANIP4="127.0.0.1"
+fi
+
 # Function for adding a RRset (subddomain)
 add_desec_subdomain() {
 curl -X POST https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/ \
@@ -45,7 +51,7 @@ curl -X POST https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/ \
       "subname": "$SUBDOMAIN",
       "type": "A",
       "ttl": 60,
-      "records": ["127.0.0.1"]
+      "records": ["$WANIP4"]
     }
 EOF
 }
@@ -63,7 +69,7 @@ curl https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/"$SUBDOMAIN"/A/ \
 ####################
 
 # Check if it's installed
-if check_desec_subdomain "$SUBDOMAIN" | grep -Po "Not found"
+if check_desec_subdomain | grep -Po "Not found"
 then
     # Ask for installing
     install_popup "$SCRIPT_NAME"
@@ -84,7 +90,7 @@ else
         fi
     done
     # Remove from DDclient
-    sed '/$SUBDOMAIN/d' /etc/ddclient.conf
+    sed "/$SUBDOMAIN/d" /etc/ddclient.conf
     systemctl restart ddclient
     # Show successful uninstall if applicable
     removal_popup "$SCRIPT_NAME"

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -30,7 +30,7 @@ then
         DEDYN_NAME=$(grep DEDYN_NAME "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
     else
         msg_box "It seems like deSEC isn't configured on this server.
-Please run sudo bash $SCRIPTS/menu.sh --> Server Configuration --> deSEC to configure it."
+Please run 'sudo bash $SCRIPTS/menu.sh --> Server Configuration --> deSEC' to configure it."
         exit 1
     fi
 fi

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -1,0 +1,58 @@
+source /var/scripts/fetch_lib.sh
+
+if [ -f "$SCRIPTS"/deSEC/.dedynauth ] && [ -f [ /etc/ddclient.conf ]
+then
+    DEDYN_TOKEN=$(grep DEDYN_TOKEN "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
+    DEDYN_NAME=$(grep DEDYN_NAME "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
+else
+    msg_box "It seems like deSEC isn't configured on this server.
+Please run sudo bash $SCRIPTS/menu.sh --> Server Configuration --> deSEC to configure it."
+    exit 1
+fi
+
+# Ask for subdomain
+SUBDOMAIN=$(input_box_flow "Please enter the subdomain you are using for $1, e.g: yoursubdomain")
+
+# Function for adding a RRset (subddomain)
+add_desec_subdomain() {
+curl -X POST https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/ \
+        --header "Authorization: Token $DEDYN_TOKEN" \
+        --header "Content-Type: application/json" --data @- <<EOF
+    {
+      "subname": "$SUBDOMAIN",
+      "type": "A",
+      "ttl": 60,
+      "records": ["127.0.0.1"]
+    }
+EOF
+}
+
+# Add the subdomain, but wait for throttling if it's there
+while :
+do
+    if grep -r "throttled" | add_desec_subdomain
+    then
+        print_text_in_color "$IRed" "Still throttling..."
+        msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to add the domain..."
+        countdown "Waiting for throttling to end, please wait for the script to continue..." "10"
+        add_desec_subdomain
+    else
+        break
+    fi
+done
+
+# Export the final subdomain for use in other scripts
+export FINAL_SUBDOMAIN="$SUBDOMAIN.$DEDYN_NAME"
+
+# Add domain to ddclient
+if grep -q "$DEDYN_NAME" /etc/ddclient.conf
+then
+    echo "$FINAL_SUBDOMAIN" >> /etc/ddclient.conf
+    systemctl restart ddclient
+    if ddclient -syslog -noquiet -verbose -force
+    then
+        msg_box "$FINAL_SUBDOMAIN was sucessfully updated."
+    else
+        msg_box "$FINAL_SUBDOMAIN failed to update, please report this to $ISSUES"
+        exit
+fi

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -21,6 +21,7 @@ debug_mode
 # Must be root
 root_check
 
+# Check if deSEC is installed and add the needed variables if yes
 if [ -f "$SCRIPTS"/deSEC/.dedynauth ]
 then
     if [ -f /etc/ddclient.conf ]
@@ -34,6 +35,7 @@ Please run sudo bash $SCRIPTS/menu.sh --> Server Configuration --> deSEC to conf
     fi
 fi
 
+# Ask for subdomain
 SUBDOMAIN=$(input_box_flow "Please enter the subdomain you want to add or delete, e.g: yoursubdomain")
 
 print_text_in_color "$ICyan" "Checking current WAN address (IPv4)..."
@@ -42,7 +44,7 @@ then
     WANIP4="127.0.0.1"
 fi
 
-# Function for adding a RRset (subddomain)
+# Function for adding an RRset (subddomain)
 add_desec_subdomain() {
 curl -X POST https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/ \
         --header "Authorization: Token $DEDYN_TOKEN" \
@@ -56,11 +58,13 @@ curl -X POST https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/ \
 EOF
 }
 
+# Function for deleting an RRset (subddomain)
 delete_desec_subdomain() {
 curl -X DELETE https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/"$SUBDOMAIN"/A/ \
     --header "Authorization: Token $DEDYN_TOKEN"
 }
 
+# Function for checking if an RRset (subddomain) exists
 check_desec_subdomain() {
 curl https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/"$SUBDOMAIN"/A/ \
     --header "Authorization: Token $DEDYN_TOKEN"
@@ -68,7 +72,7 @@ curl https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/"$SUBDOMAIN"/A/ \
 
 ####################
 
-# Check if it's installed
+# Check the subdomain exist within the domain
 if check_desec_subdomain | grep -Po "Not found"
 then
     # Ask for installing

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -34,7 +34,7 @@ do
     then
         print_text_in_color "$IRed" "Still throttling..."
         msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to add the domain..."
-        countdown "Waiting for throttling to end, please wait for the script to continue..." "10"
+        countdown "Waiting for throttling to end, please wait for the script to continue..." "600"
         add_desec_subdomain
     else
         break
@@ -51,7 +51,7 @@ then
     systemctl restart ddclient
     if ddclient -syslog -noquiet -verbose -force
     then
-        msg_box "$FINAL_SUBDOMAIN was sucessfully updated."
+        msg_box "$FINAL_SUBDOMAIN was successfully updated."
     else
         msg_box "$FINAL_SUBDOMAIN failed to update, please report this to $ISSUES"
         exit

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -86,7 +86,7 @@ else
         if delete_desec_subdomain | grep -Po "throttled"
         then
             print_text_in_color "$IRed" "Still throttling..."
-            msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to delete $SUBDOMAIN(.DEDYN_NAME)..."
+            msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to delete $SUBDOMAIN(.$DEDYN_NAME)..."
             countdown "Waiting for throttling to end, please wait for the script to continue..." "600"
             delete_desec_subdomain
         else
@@ -108,7 +108,7 @@ do
     if add_desec_subdomain | grep -Po "throttled"
     then
         print_text_in_color "$IRed" "Still throttling..."
-        msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to add $SUBDOMAIN(.DEDYN_NAME)..."
+        msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to add $SUBDOMAIN(.$DEDYN_NAME)..."
         countdown "Waiting for throttling to end, please wait for the script to continue..." "600"
         add_desec_subdomain
     else

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -120,4 +120,5 @@ then
     else
         msg_box "$FINAL_SUBDOMAIN failed to update, please report this to $ISSUES"
         exit
+    fi
 fi

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -21,54 +21,18 @@ debug_mode
 # Must be root
 root_check
 
-# Both deSEC and ddclient are required for this to work
 if [ ! -f "$SCRIPTS"/deSEC/.dedynauth ]
 then
     if [ ! -f /etc/ddclient.conf ]
     then
-        # Ask for installing
-        install_popup "$SCRIPT_NAME"
         DEDYN_TOKEN=$(grep DEDYN_TOKEN "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
         DEDYN_NAME=$(grep DEDYN_NAME "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
     else
-        # Ask for removal or reinstallation
-        reinstall_remove_menu "$SCRIPT_NAME"
-        DEDYN_TOKEN=$(grep DEDYN_TOKEN "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
-        DEDYN_NAME=$(grep DEDYN_NAME "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
-        SUBDOMAIN=$(input_box_flow "Please enter the subdomain you want to delete, e.g: yoursubdomain")
-        # Function to delete deSEC subdomain
-delete_desec_subdomain() {
-curl -X DELETE https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/ \
-    --header "Authorization: Token DEDYN_TOKEN" \
-    --header "Content-Type: application/json" --data @- <<EOF
-    {
-      "subname": "$SUBDOMAIN",
-      "type": "A",
-      "ttl": 60,
-      "records": [""]},
-    }
-EOF
-}
-        # Delete the subdomain, but wait for throttling if it's there
-        while :
-        do
-            if grep -r "throttled" | delete_desec_subdomain
-            then
-                print_text_in_color "$IRed" "Still throttling..."
-                msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to delete the domain..."
-                countdown "Waiting for throttling to end, please wait for the script to continue..." "600"
-                delete_desec_subdomain
-            else
-                break
-            fi
-        done
-        # Show successful uninstall if applicable
-        removal_popup "$SCRIPT_NAME"
+        msg_box "It seems like deSEC isn't configured on this server.
+Please run sudo bash $SCRIPTS/menu.sh --> Server Configuration --> deSEC to configure it."
+        exit 1
     fi
 fi
-
-# Ask for subdomain
-SUBDOMAIN=$(input_box_flow "Please enter the subdomain you want to add, e.g: yoursubdomain")
 
 # Function for adding a RRset (subddomain)
 add_desec_subdomain() {
@@ -83,6 +47,50 @@ curl -X POST https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/ \
     }
 EOF
 }
+
+delete_desec_subdomain() {
+curl -X DELETE https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/ \
+    --header "Authorization: Token DEDYN_TOKEN" \
+    --header "Content-Type: application/json" --data @- <<EOF
+    {
+      "subname": "$SUBDOMAIN",
+      "type": "A",
+      "ttl": 60,
+      "records": [""]},
+    }
+EOF
+}
+
+# Both deSEC and ddclient are required for this to work
+if ! curl -X GET https://desec.io/api/v1/domains/"$DEDYN_NAME"/ \
+    --header "Authorization: Token $DEDYN_TOKEN"
+then
+    # Ask for installing
+    install_popup "$SCRIPT_NAME"
+else
+    # Ask for removal or reinstallation
+    reinstall_remove_menu "$SCRIPT_NAME"
+    # Ask for subdomain to delete
+    SUBDOMAIN=$(input_box_flow "Please enter the subdomain you want to delete, e.g: yoursubdomain")
+    # Delete the subdomain, but wait for throttling if it's there
+    while :
+    do
+        if grep -r "throttled" | delete_desec_subdomain
+        then
+            print_text_in_color "$IRed" "Still throttling..."
+            msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to delete the domain..."
+            countdown "Waiting for throttling to end, please wait for the script to continue..." "600"
+            delete_desec_subdomain
+        else
+            break
+        fi
+    done
+    # Show successful uninstall if applicable
+    removal_popup "$SCRIPT_NAME"
+fi
+
+# Ask for subdomain to add
+SUBDOMAIN=$(input_box_flow "Please enter the subdomain you want to add, e.g: yoursubdomain")
 
 # Add the subdomain, but wait for throttling if it's there
 while :

--- a/addons/desec_subdomain.sh
+++ b/addons/desec_subdomain.sh
@@ -1,17 +1,74 @@
-source /var/scripts/fetch_lib.sh
+#!/bin/bash
 
-if [ -f "$SCRIPTS"/deSEC/.dedynauth ] && [ -f /etc/ddclient.conf ]
+# T&M Hansson IT AB © - 2021, https://www.hanssonit.se/
+# SwITNet Ltd © - 2021, https://switnet.net/
+
+true
+SCRIPT_NAME="deSEC Subdomain"
+SCRIPT_EXPLAINER="This script enables you to add a subdomain to your existing deSEC domain.
+
+You need to have a deSEC account already configured for this to work. If you don't already have an account configured, please run:
+sudo bash $SCRIPTS/menu.sh --> Server Configuration --> deSEC"
+# shellcheck source=lib.sh
+source /var/scripts/fetch_lib.sh || source <(curl -sL https://raw.githubusercontent.com/nextcloud/vm/master/lib.sh)
+
+# Check for errors + debug code and abort if something isn't right
+# 1 = ON
+# 0 = OFF
+DEBUG=0
+debug_mode
+
+# Must be root
+root_check
+
+# Both deSEC and ddclient are required for this to work
+if [ ! -f "$SCRIPTS"/deSEC/.dedynauth ]
 then
-    DEDYN_TOKEN=$(grep DEDYN_TOKEN "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
-    DEDYN_NAME=$(grep DEDYN_NAME "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
-else
-    msg_box "It seems like deSEC isn't configured on this server.
-Please run sudo bash $SCRIPTS/menu.sh --> Server Configuration --> deSEC to configure it."
-    exit 1
+    if [ ! -f /etc/ddclient.conf ]
+    then
+        # Ask for installing
+        install_popup "$SCRIPT_NAME"
+        DEDYN_TOKEN=$(grep DEDYN_TOKEN "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
+        DEDYN_NAME=$(grep DEDYN_NAME "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
+    else
+        # Ask for removal or reinstallation
+        reinstall_remove_menu "$SCRIPT_NAME"
+        DEDYN_TOKEN=$(grep DEDYN_TOKEN "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
+        DEDYN_NAME=$(grep DEDYN_NAME "$SCRIPTS"/deSEC/.dedynauth | cut -d '=' -f2)
+        SUBDOMAIN=$(input_box_flow "Please enter the subdomain you want to delete, e.g: yoursubdomain")
+        # Function to delete deSEC subdomain
+delete_desec_subdomain() {
+curl -X DELETE https://desec.io/api/v1/domains/"$DEDYN_NAME"/rrsets/ \
+    --header "Authorization: Token DEDYN_TOKEN" \
+    --header "Content-Type: application/json" --data @- <<EOF
+    {
+      "subname": "$SUBDOMAIN",
+      "type": "A",
+      "ttl": 60,
+      "records": [""]},
+    }
+EOF
+}
+        # Delete the subdomain, but wait for throttling if it's there
+        while :
+        do
+            if grep -r "throttled" | delete_desec_subdomain
+            then
+                print_text_in_color "$IRed" "Still throttling..."
+                msg_box "To avoid throttling, we're now waiting for 5 minutes to be able to delete the domain..."
+                countdown "Waiting for throttling to end, please wait for the script to continue..." "600"
+                delete_desec_subdomain
+            else
+                break
+            fi
+        done
+        # Show successful uninstall if applicable
+        removal_popup "$SCRIPT_NAME"
+    fi
 fi
 
 # Ask for subdomain
-SUBDOMAIN=$(input_box_flow "Please enter the subdomain you are using for $1, e.g: yoursubdomain")
+SUBDOMAIN=$(input_box_flow "Please enter the subdomain you want to add, e.g: yoursubdomain")
 
 # Function for adding a RRset (subddomain)
 add_desec_subdomain() {
@@ -51,7 +108,7 @@ then
     systemctl restart ddclient
     if ddclient -syslog -noquiet -verbose -force
     then
-        msg_box "$FINAL_SUBDOMAIN was successfully updated."
+        msg_box "$FINAL_SUBDOMAIN was successfully added and updated."
     else
         msg_box "$FINAL_SUBDOMAIN failed to update, please report this to $ISSUES"
         exit


### PR DESCRIPTION
This script makes it possible to add a subdomain to an already existing deSEC account.

It also checks if the domain already exists, and deletes it with the option to activate it again, and thus updating the IP address with DDclient - or completley removes it.

Rate-limiting is taken into account as well.