### PR TITLE
Don't execute the update before all cronjobs are finished

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -431,6 +431,15 @@ do
 done
 }
 
+# Fix issues like https://github.com/nextcloud/spreed/issues/5518
+check_running_cronjobs() {
+    while [ -n "$(pgrep -f nextcloud/cron.php)" ]
+    do
+        print_text_in_color "$ICyan" "Waiting for the Nextclouds cronjob to finish..."
+        sleep 5
+    done
+}
+
 # Checks if site is reachable with a HTTP 200 status
 site_200() {
 print_text_in_color "$ICyan" "Checking connection..."

--- a/nextcloud_update.sh
+++ b/nextcloud_update.sh
@@ -901,6 +901,9 @@ then
     rsync -Aaxz $BACKUP/config "$NCPATH"/
     bash $SECURE & spinner_loading
     nextcloud_occ maintenance:mode --off
+    # Don't execute the update before all cronjobs are finished
+    check_running_cronjobs
+    # Execute the update
     nextcloud_occ upgrade
     # Optimize
     print_text_in_color "$ICyan" "Optimizing Nextcloud..."
@@ -1014,6 +1017,9 @@ then
                     rsync -Aaxz "$BACKUP/apps/$app" "$NC_APPS_PATH/"
                     bash "$SECURE"
                     nextcloud_occ_no_check app:disable "$app"
+                    # Don't execute the update before all cronjobs are finished
+                    check_running_cronjobs
+                    # Execute the update
                     nextcloud_occ upgrade
                 fi
             fi


### PR DESCRIPTION
Prevents issues like https://github.com/nextcloud/spreed/issues/5518
Is discussed in https://github.com/nextcloud/server/issues/28508
Signed-off-by: szaimen <szaimen@e.mail.de>