### PR TITLE
Deal with CVE-2021-44228 by modifying ES_JAVA_OPTS

### DIFF
--- a/apps/fulltextsearch.sh
+++ b/apps/fulltextsearch.sh
@@ -120,7 +120,7 @@ docker run -d --restart always \
 -v /opt/es/readonlyrest.yml:/usr/share/elasticsearch/config/readonlyrest.yml \
 -e "discovery.type=single-node" \
 -e "bootstrap.memory_lock=true" \
--e ES_JAVA_OPTS="-Xms1024M -Xmx1024M" \
+-e ES_JAVA_OPTS="-Xms1024M -Xmx1024M -Dlog4j2.formatMsgNoLookups=true" \
 -i -t $nc_fts
 
 # Wait for bootstrapping


### PR DESCRIPTION
Mitigating CVE-2021-44228 'til new upstream source is defined.