### PR TITLE
fix janus conf

### DIFF
--- a/apps/talk.sh
+++ b/apps/talk.sh
@@ -262,7 +262,7 @@ echo "deb https://packaging.gitlab.io/janus/$DISTRIB_CODENAME $DISTRIB_CODENAME 
 apt-get update -q4 & spinner_loading
 install_if_not janus
 ## Configuration
-sed -i "s|#turn_rest_api_key\s*=.*|$JANUS_API_KEY|" /etc/janus/janus.jcfg
+sed -i "s|#turn_rest_api_key.*|turn_rest_api_key = $JANUS_API_KEY|" /etc/janus/janus.jcfg
 sed -i "s|#full_trickle|full_trickle|g" /etc/janus/janus.jcfg
 sed -i 's|#interface.*|interface = "lo"|g' /etc/janus/janus.transport.websockets.jcfg
 sed -i 's|#ws_interface.*|ws_interface = "lo"|g' /etc/janus/janus.transport.websockets.jcfg


### PR DESCRIPTION
Before this fix, it would overwrite the whole line with the key. Now it works in my testing. I am using the same syntax like two lines below that.

Signed-off-by: szaimen <szaimen@e.mail.de>