### PR TITLE
Revert "update janus repo url (#2218)"

### DIFF
--- a/apps/talk.sh
+++ b/apps/talk.sh
@@ -258,7 +258,7 @@ check_command systemctl enable nats-server
 # shellcheck disable=SC1091
 source /etc/lsb-release
 curl -sL -o "/etc/apt/trusted.gpg.d/morph027-janus.asc" "https://packaging.gitlab.io/janus/gpg.key"
-echo "deb https://packaging.gitlab.io/janus $DISTRIB_CODENAME main" > /etc/apt/sources.list.d/morph027-janus.list
+echo "deb https://packaging.gitlab.io/janus/$DISTRIB_CODENAME $DISTRIB_CODENAME main" > /etc/apt/sources.list.d/morph027-janus.list
 apt-get update -q4 & spinner_loading
 install_if_not janus
 ## Configuration


### PR DESCRIPTION
This reverts commit 6bb6ebf31ce31992b4de9b10af0e5b308e0794df.

Sorry for the whitenoise, needed to split up the repos again (i knew there was a reason in the past, just couldn't figure it out ;) ). Repo is back to the old URL again.