### PR TITLE
Adjust openssl serial file use on 3.0

### DIFF
--- a/apps/opensearch_certs.sh
+++ b/apps/opensearch_certs.sh
@@ -40,6 +40,6 @@ mv client.pem \
    root-ca-key.pem -t tls_store
 
 # openssl 3.0 workaround
-if [ $(lsb_release -sr) = 20.04 ]; then
+if [ "$(lsb_release -sr)" = "20.04" ]; then
    mv root-ca.srl tls_store
 fi

--- a/apps/opensearch_certs.sh
+++ b/apps/opensearch_certs.sh
@@ -37,5 +37,9 @@ rm admin-key-temp.pem \
 # Store
 mv client.pem \
    client-key.pem \
-   root-ca.srl \
    root-ca-key.pem -t tls_store
+
+# openssl 3.0 workaround
+if [ $(lsb_release -sr) = 20.04 ]; then
+   mv root-ca.srl tls_store
+fi


### PR DESCRIPTION
openssl 3.0.x (jammy's version) does not create serial file anymore, so only moving on 20.04 (openssl 1.1.1).