### PR TITLE
Add menu item for Google Domains

### DIFF
--- a/network/ddclient-configuration.sh
+++ b/network/ddclient-configuration.sh
@@ -63,6 +63,7 @@ $MENU_GUIDE\n\n$RUN_LATER_GUIDE" "$WT_HEIGHT" "$WT_WIDTH" 4 \
 "Cloudflare" "(cloudflare.com)" \
 "deSEC" "(desec.io)" \
 "Duck DNS" "(duckdns.org)" \
+"Google Domains" "(domains.google)" \
 "No-IP" "(noip.com)" \
 "Strato" "(strato.de)" 3>&1 1>&2 2>&3)
 fi
@@ -90,6 +91,14 @@ case "$choice" in
         GUIDE="https://www.duckdns.org/faqs.jsp"
         PROTOCOL="duckdns"
         SERVER="www.duckdns.org"
+        USE_SSL="yes"
+    ;;
+    "Google Domains")
+        PROVIDER="Google Domains"
+        INSTRUCTIONS="activate DynDNS for your Domain"
+        GUIDE="https://support.google.com/domains/answer/6147083"
+        PROTOCOL="dyndns2"
+        SERVER="domains.google.com"
         USE_SSL="yes"
     ;;
     "No-IP")


### PR DESCRIPTION
1. Add menu item for Google Domains in alphabetical position
2. Add configuration section for Google Domains.
3. Instructions: copied section from "strato" section because it mentions getting "ddns for your domain", not "ddns account" like the other account types
4. Guide: use Google's own DDNS instructions page
5. Protocol: use "dyndns2" not "googledomains" even though it is is supported natively in ddclient 3.9+. Reason: ddns updates always succeed if protocol set to "googledomains" even when using junk data. Google DDNS support page says both update methods using ddclient are supported. 