### PR TITLE
increase turnserver quota

### DIFF
--- a/apps/talk.sh
+++ b/apps/talk.sh
@@ -133,7 +133,7 @@ fingerprint
 use-auth-secret
 static-auth-secret=$TURN_SECRET
 realm=$TURN_DOMAIN
-total-quota=100
+total-quota=0
 bps-capacity=0
 stale-nonce
 no-loopback-peers


### PR DESCRIPTION
Seems like this increases available connections behind NAT. See [this report](https://github.com/nextcloud/all-in-one/issues/1121#issuecomment-1241802920).

Signed-off-by: szaimen <szaimen@e.mail.de>