### PR TITLE
Update system-restore.sh and backup-viewer.sh

### DIFF
--- a/not-supported/backup-viewer.sh
+++ b/not-supported/backup-viewer.sh
@@ -37,7 +37,7 @@ Please do that before you can view backups."
     exit 1
 fi
 # Get needed variables
-ENCRYPTION_KEY="$(grep "ENCRYPTION_KEY=" "$DAILY_BACKUP_FILE" | sed 's|.*ENCRYPTION_KEY="||;s|"||')"
+ENCRYPTION_KEY="$(grep "ENCRYPTION_KEY=" "$DAILY_BACKUP_FILE" | sed "s|.*ENCRYPTION_KEY=||;s|'||g;s|\"||g")"
 DAILY_BACKUP_MOUNTPOINT="$(grep "BACKUP_MOUNTPOINT=" "$DAILY_BACKUP_FILE" | sed 's|.*BACKUP_MOUNTPOINT="||;s|"||')"
 DAILY_BACKUP_TARGET="$(grep "BACKUP_TARGET_DIRECTORY=" "$DAILY_BACKUP_FILE" | sed 's|.*BACKUP_TARGET_DIRECTORY="||;s|"||')"
 if [ -z "$ENCRYPTION_KEY" ] || [ -z "$DAILY_BACKUP_FILE" ] || [ -z "$DAILY_BACKUP_FILE" ]

--- a/not-supported/system-restore.sh
+++ b/not-supported/system-restore.sh
@@ -64,7 +64,7 @@ Please do that before you can view backups."
     exit 1
 fi
 # Get needed variables
-ENCRYPTION_KEY="$(grep "ENCRYPTION_KEY=" "$DAILY_BACKUP_FILE" | sed 's|.*ENCRYPTION_KEY="||;s|"||')"
+ENCRYPTION_KEY="$(grep "ENCRYPTION_KEY=" "$DAILY_BACKUP_FILE" | sed 's|.*ENCRYPTION_KEY=\x27||;s|\x27||')"
 DAILY_BACKUP_MOUNTPOINT="$(grep "BACKUP_MOUNTPOINT=" "$DAILY_BACKUP_FILE" | sed 's|.*BACKUP_MOUNTPOINT="||;s|"||')"
 DAILY_BACKUP_TARGET="$(grep "BACKUP_TARGET_DIRECTORY=" "$DAILY_BACKUP_FILE" | sed 's|.*BACKUP_TARGET_DIRECTORY="||;s|"||')"
 if [ -z "$ENCRYPTION_KEY" ] || [ -z "$DAILY_BACKUP_FILE" ] || [ -z "$DAILY_BACKUP_FILE" ]

--- a/not-supported/system-restore.sh
+++ b/not-supported/system-restore.sh
@@ -64,7 +64,7 @@ Please do that before you can view backups."
     exit 1
 fi
 # Get needed variables
-ENCRYPTION_KEY="$(grep "ENCRYPTION_KEY=" "$DAILY_BACKUP_FILE" | sed 's|.*ENCRYPTION_KEY=\x27||;s|\x27||')"
+ENCRYPTION_KEY="$(grep "ENCRYPTION_KEY=" "$DAILY_BACKUP_FILE" | sed "s|.*ENCRYPTION_KEY=||;s|'||g;s|\"||g")"
 DAILY_BACKUP_MOUNTPOINT="$(grep "BACKUP_MOUNTPOINT=" "$DAILY_BACKUP_FILE" | sed 's|.*BACKUP_MOUNTPOINT="||;s|"||')"
 DAILY_BACKUP_TARGET="$(grep "BACKUP_TARGET_DIRECTORY=" "$DAILY_BACKUP_FILE" | sed 's|.*BACKUP_TARGET_DIRECTORY="||;s|"||')"
 if [ -z "$ENCRYPTION_KEY" ] || [ -z "$DAILY_BACKUP_FILE" ] || [ -z "$DAILY_BACKUP_FILE" ]


### PR DESCRIPTION
Compare https://github.com/nextcloud/vm/blob/master/not-supported/daily-backup-wizard.sh#L437

Fixed issue with inconsistent quotes related to ENCRYPTION_KEY
sed did not replace the normal ticks, which caused it to be considered part of the password, which is why during restoration it reported that the password was incorrect.

Signed-off-by: Florian Helmschmidt <github@nhelmschmidt.de>