### PR TITLE
Check for empty $INFECTED_FILES

### DIFF
--- a/apps/clamav.sh
+++ b/apps/clamav.sh
@@ -246,6 +246,11 @@ fi
 INFECTED_FILES_LOG="\$(sed -n '/----------- SCAN SUMMARY -----------/,\$p' $VMLOGS/clamav-fullscan.log)"
 INFECTED_FILES="\$(grep 'FOUND$' $VMLOGS/clamav-fullscan.log)"
 
+if [ -z "$INFECTED_FILES" ];
+then
+    INFECTED_FILES="No infected files found"
+fi
+
 # Send notification
 if ! send_mail "Your weekly full-scan ClamAV report" "\$INFECTED_FILES_LOG\n
 \$INFECTED_FILES"

--- a/apps/clamav.sh
+++ b/apps/clamav.sh
@@ -246,7 +246,7 @@ fi
 INFECTED_FILES_LOG="\$(sed -n '/----------- SCAN SUMMARY -----------/,\$p' $VMLOGS/clamav-fullscan.log)"
 INFECTED_FILES="\$(grep 'FOUND$' $VMLOGS/clamav-fullscan.log)"
 
-if [ -z "$INFECTED_FILES" ];
+if [ -z "$INFECTED_FILES" ]
 then
     INFECTED_FILES="No infected files found"
 fi


### PR DESCRIPTION
Fixes #2593

This checks to see if the string is empty, if it is then it assigns a placeholder 'No infected files found' message so that the `notify_admin_gui` or rather the `nextcloud_occ_no_check notification:generate -l "$2" "$admin" "$1"` correctly runs