### PR TITLE
Nextcloud add new backup options

### DIFF
--- a/not-supported/cloudbackup.sh
+++ b/not-supported/cloudbackup.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# T&M Hansson IT AB © - 2024, https://www.hanssonit.se/
+# Sami Nieminen - 2024 https://nenimein.fi
+true
+
+SCRIPT_NAME="Nextcloud Cloud Backup Wizard"
+SCRIPT_EXPLAINER="This script helps creating a backup script for your Nextcloud instance to various cloud storage providers."
+
+# shellcheck source=lib.sh
+source /var/scripts/fetch_lib.sh
+
+# Check for errors + debug code and abort if something isn't right
+# 1 = ON
+# 0 = OFF
+DEBUG=0
+debug_mode
+
+# Check if root
+root_check
+
+# Variables
+BACKUP_SCRIPT_NAME="$SCRIPTS/cloudbackup.sh"
+BACKUP_CONFIG="$HOME/.cloud_backup_config"
+
+# Functions
+choose_backup_location() {
+    BACKUP_TYPE=$(whiptail --title "$TITLE" --menu \
+        "Choose backup destination" "$WT_HEIGHT" "$WT_WIDTH" 4 \
+        "Backblaze B2" "" \
+        "AWS S3" "" \
+        "Azure Blob" "" 3>&1 1>&2 2>&3)
+
+    case "$BACKUP_TYPE" in
+        "Backblaze B2")
+            B2_ACCOUNT_ID=$(input_box_flow "Enter Backblaze B2 Account ID:")
+            B2_ACCOUNT_KEY=$(input_box_flow "Enter Backblaze B2 Account Key:")
+            B2_BUCKET_NAME=$(input_box_flow "Enter B2 Bucket Name:")
+            RESTIC_REPOSITORY="b2:$B2_BUCKET_NAME:"
+            ;;
+        "AWS S3")
+            AWS_ACCESS_KEY_ID=$(input_box_flow "Enter AWS Access Key ID:")
+            AWS_SECRET_ACCESS_KEY=$(input_box_flow "Enter AWS Secret Access Key:")
+            AWS_DEFAULT_REGION=$(input_box_flow "Enter AWS Region (e.g., us-east-1):")
+            S3_BUCKET_NAME=$(input_box_flow "Enter S3 Bucket Name:")
+            RESTIC_REPOSITORY="s3:s3.${AWS_DEFAULT_REGION}.amazonaws.com/${S3_BUCKET_NAME}"
+            ;;
+        "Azure Blob")
+            AZURE_ACCOUNT_NAME=$(input_box_flow "Enter Azure Storage Account Name:")
+            AZURE_ACCOUNT_KEY=$(input_box_flow "Enter Azure Storage Account Key:")
+            AZURE_CONTAINER_NAME=$(input_box_flow "Enter Azure Container Name:")
+            RESTIC_REPOSITORY="azure:${AZURE_CONTAINER_NAME}:"
+            ;;
+        *)
+            msg_box "Invalid selection"
+            exit 1
+            ;;
+    esac
+
+    # Configure restic password
+    RESTIC_PASSWORD=$(input_box_flow "Enter Restic Repository Password:")
+}
+
+# Ask for execution
+msg_box "$SCRIPT_EXPLAINER"
+if ! yesno_box_yes "Do you want to create a backup script?"
+then
+    exit
+fi
+
+# Check if script already exists
+if [ -f "$BACKUP_SCRIPT_NAME" ]
+then
+    msg_box "The backup script already exists. Please rename or delete $BACKUP_SCRIPT_NAME if you want to reconfigure the backup."
+    exit 1
+fi
+
+# Install restic if not installed
+if ! command -v restic &> /dev/null
+then
+    msg_box "Installing restic..."
+    apt-get update -q4 & spinner_loading
+    apt-get install restic -y
+fi
+
+# Configure PostgreSQL credentials
+POSTGRES_USER=$NCDBUSER
+POSTGRES_PASSWORD=$NCDBPASS
+
+# Configure backup destination
+choose_backup_location
+
+# Configure retention policy
+BACKUP_RETENTION_DAILY=$(input_box_flow "Enter number of daily backups to keep:" "7")
+BACKUP_RETENTION_WEEKLY=$(input_box_flow "Enter number of weekly backups to keep:" "4")
+BACKUP_RETENTION_MONTHLY=$(input_box_flow "Enter number of monthly backups to keep:" "3")
+
+# Configure backup time
+if yesno_box_yes "Do you want to run the backup at the recommended time 4:00 AM?"
+then
+    BACKUP_TIME="00 04"
+else
+    while :
+    do
+        BACKUP_TIME=$(input_box_flow "Enter backup time (mm hh format, e.g. '00 04' for 4:00 AM):")
+        if echo "$BACKUP_TIME" | grep -qE "^[0-5][0-9] ([01][0-9]|2[0-3])$"
+        then
+            break
+        fi
+        msg_box "Invalid time format. Please use mm hh format (e.g. '00 04' for 4:00 AM)"
+    done
+fi
+
+# Save configuration
+cat > "$BACKUP_CONFIG" << EOL
+POSTGRES_USER="$POSTGRES_USER"
+POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
+BACKUP_TYPE="$BACKUP_TYPE"
+RESTIC_PASSWORD="$RESTIC_PASSWORD"
+RESTIC_REPOSITORY="$RESTIC_REPOSITORY"
+BACKUP_RETENTION_DAILY="$BACKUP_RETENTION_DAILY"
+BACKUP_RETENTION_WEEKLY="$BACKUP_RETENTION_WEEKLY"
+BACKUP_RETENTION_MONTHLY="$BACKUP_RETENTION_MONTHLY"
+
+# B2 Configuration
+B2_ACCOUNT_ID="$B2_ACCOUNT_ID"
+B2_ACCOUNT_KEY="$B2_ACCOUNT_KEY"
+B2_BUCKET_NAME="$B2_BUCKET_NAME"
+
+# AWS S3 Configuration
+AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION"
+S3_BUCKET_NAME="$S3_BUCKET_NAME"
+
+# Azure Blob Configuration
+AZURE_ACCOUNT_NAME="$AZURE_ACCOUNT_NAME"
+AZURE_ACCOUNT_KEY="$AZURE_ACCOUNT_KEY"
+AZURE_CONTAINER_NAME="$AZURE_CONTAINER_NAME"
+EOL
+chmod 600 "$BACKUP_CONFIG"
+
+# Create backup script
+cat << 'BACKUP_SCRIPT' > "$BACKUP_SCRIPT_NAME"
+#!/bin/bash
+
+# T&M Hansson IT AB © - 2024, https://www.hanssonit.se/
+# Sami Nieminen - 2024 https://nenimein.fi
+true
+
+SCRIPT_NAME="Daily Restic Backup"
+SCRIPT_EXPLAINER="This script executes the daily backup to cloud storage."
+
+# shellcheck source=lib.sh
+source /var/scripts/fetch_lib.sh
+
+# Load configuration
+source "$HOME/.restic_backup_config"
+
+# Export environment variables based on backup type
+case "$BACKUP_TYPE" in
+    "Backblaze B2")
+        export B2_ACCOUNT_ID="$B2_ACCOUNT_ID"
+        export B2_ACCOUNT_KEY="$B2_ACCOUNT_KEY"
+        ;;
+    "AWS S3")
+        export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+        export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+        export AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION"
+        ;;
+    "Azure Blob")
+        export AZURE_ACCOUNT_NAME="$AZURE_ACCOUNT_NAME"
+        export AZURE_ACCOUNT_KEY="$AZURE_ACCOUNT_KEY"
+        ;;
+esac
+
+export RESTIC_REPOSITORY="$RESTIC_REPOSITORY"
+export RESTIC_PASSWORD="$RESTIC_PASSWORD"
+
+# Execute backup if network is available
+if network_ok
+then
+    # Enable maintenance mode
+    sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on
+
+    # Create backup directory
+    BACKUP_DIR="/tmp/nextcloud_backup"
+    mkdir -p "$BACKUP_DIR"
+
+    # Backup PostgreSQL database
+    PGPASSWORD="$NCDBPASS" pg_dump -U "$POSTGRES_USER" nextcloud > "$BACKUP_DIR/nextcloud_db.sql"
+
+    # Backup Nextcloud config
+    cp /var/www/nextcloud/config/config.php "$BACKUP_DIR/"
+
+    # Initialize repository if needed
+    restic snapshots || restic init
+
+    # Create backup
+    restic backup "$BACKUP_DIR" /var/www/nextcloud/data
+
+    # Clean up
+    rm -rf "$BACKUP_DIR"
+
+    # Apply retention policy
+    restic forget --keep-daily "$BACKUP_RETENTION_DAILY" \
+                  --keep-weekly "$BACKUP_RETENTION_WEEKLY" \
+                  --keep-monthly "$BACKUP_RETENTION_MONTHLY" --prune
+
+    # Check repository
+    restic check
+
+    # Disable maintenance mode
+    sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --off
+
+    # Notify on failure
+    if [ $? -ne 0 ]
+    then
+        notify_admin_gui "Restic backup failed!" "Please check the logs for more information."
+    fi
+else
+    notify_admin_gui "Unable to execute backup" "No network connection."
+fi
+BACKUP_SCRIPT
+
+# Make backup script executable
+chmod 700 "$BACKUP_SCRIPT_NAME"
+
+# Create cron job
+crontab -u root -l | grep -v "$BACKUP_SCRIPT_NAME" | crontab -u root -
+crontab -u root -l | { cat; echo "$BACKUP_TIME * * * $BACKUP_SCRIPT_NAME > /dev/null 2>&1"; } | crontab -u root -
+
+# Final message
+msg_box "The backup script has been created successfully!
+Location: $BACKUP_SCRIPT_NAME
+
+The first backup will run automatically at $BACKUP_TIME.
+Please make sure to keep your configuration and passwords safe."
+
+exit 0

--- a/not-supported/not-supported_menu.sh
+++ b/not-supported/not-supported_menu.sh
@@ -32,6 +32,7 @@ $CHECKLIST_GUIDE" "$WT_HEIGHT" "$WT_WIDTH" 4 \
 "NTFS Mount" "(Mount NTFS drives)" OFF \
 "NTFS Veracrypt" "(Format, encrypt and mount Veracrypt NTFS drives)" OFF \
 "Backup Viewer" "(View your Backups)" OFF \
+"Restic Cloud Backup" "(Backup your server using Restic to multiple clouds)" OFF \
 "Daily Backup Wizard" "(Create a Daily Backup script)" OFF \
 "Firewall" "(Setting up a firewall)" OFF \
 "Monitor Link Shares" "(Monitors the creation of link shares)" OFF \

--- a/not-supported/not-supported_menu.sh
+++ b/not-supported/not-supported_menu.sh
@@ -76,6 +76,10 @@ case "$choice" in
         print_text_in_color "$ICyan" "Downloading the Daily Backup Wizard script..."
         run_script NOT_SUPPORTED_FOLDER daily-backup-wizard
     ;;&
+    *"Cloud Backup Wizard"*)
+        print_text_in_color "$ICyan" "Downloading the Cloud Backup Wizard script..."
+        run_script NOT_SUPPORTED_FOLDER cloudbackup
+    ;;&
     *"Firewall"*)
         print_text_in_color "$ICyan" "Downloading the Firewall script..."
         run_script NOT_SUPPORTED_FOLDER firewall

--- a/not-supported/not-supported_menu.sh
+++ b/not-supported/not-supported_menu.sh
@@ -76,9 +76,9 @@ case "$choice" in
         print_text_in_color "$ICyan" "Downloading the Daily Backup Wizard script..."
         run_script NOT_SUPPORTED_FOLDER daily-backup-wizard
     ;;&
-    *"Cloud Backup Wizard"*)
+    *"Restic Cloud Backup Wizard"*)
         print_text_in_color "$ICyan" "Downloading the Cloud Backup Wizard script..."
-        run_script NOT_SUPPORTED_FOLDER cloudbackup
+        run_script NOT_SUPPORTED_FOLDER restic-cloud-backup-wizard
     ;;&
     *"Firewall"*)
         print_text_in_color "$ICyan" "Downloading the Firewall script..."

--- a/not-supported/restic-cloud-backup-wizard.sh
+++ b/not-supported/restic-cloud-backup-wizard.sh
@@ -36,12 +36,6 @@ BACKUP_CONFIG="$HOME/.restic_cloud_backup_config"
 # https://forum.restic.net/t/version-0-16-4-and-azure-blob/7864
 # https://salsa.debian.org/go-team/packages/restic/-/tree/master/debian/patches?ref_type=heads
 install_restic() {
-    # Check if restic is already installed with correct version
-    if [ -x "$(command -v restic)" ]; then
-        INSTALLED_VERSION=$(restic version | grep "restic" | awk '{print $2}')
-        print_text_in_color "$ICyan" "Restic $INSTALLED_VERSION is already installed, checking for newer version..."
-    fi
-
     # Get latest version from GitHub API
     print_text_in_color "$ICyan" "Getting latest restic version..."
     LATEST_VERSION=$(curl -s https://api.github.com/repos/restic/restic/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
@@ -53,8 +47,14 @@ install_restic() {
     # Remove 'v' prefix from version for comparison and binary download
     LATEST_VERSION_CLEAN=${LATEST_VERSION#v}
 
+    # Check if restic is already installed with correct version
+    if [ -x "$(command -v restic)" ]; then
+        INSTALLED_VERSION=$(restic version | grep "restic" | awk '{print $2}')
+        print_text_in_color "$ICyan" "Restic $INSTALLED_VERSION is already installed, checking for newer version..."
+    fi
+
     # Check if we need to upgrade
-    if [ -n "$INSTALLED_VERSION" ] && [ "$INSTALLED_VERSION" = "$LATEST_VERSION" ]; then
+    if [ -n "$INSTALLED_VERSION" ] && [ "$INSTALLED_VERSION" = "$LATEST_VERSION_CLEAN" ]; then
         print_text_in_color "$IGreen" "Latest version $LATEST_VERSION is already installed!"
         return 0
     fi

--- a/not-supported/restic-cloud-backup-wizard.sh
+++ b/not-supported/restic-cloud-backup-wizard.sh
@@ -129,7 +129,7 @@ choose_backup_location() {
             AZURE_ACCOUNT_NAME=$(input_box_flow "Enter Azure Storage Account Name")
             AZURE_ACCOUNT_KEY=$(input_box_flow "Enter Azure Storage Account Key:")
             AZURE_CONTAINER_NAME=$(input_box_flow "Enter Azure Storage Account Blob name:")
-            RESTIC_REPOSITORY="azure:${AZURE_ACCOUNT_NAME}:/${AZURE_CONTAINER_NAME}"
+            RESTIC_REPOSITORY="azure:${AZURE_ACCOUNT_NAME}:/"
             ;;
         *)
             msg_box "Invalid selection"

--- a/not-supported/restic-cloud-backup-wizard.sh
+++ b/not-supported/restic-cloud-backup-wizard.sh
@@ -50,6 +50,9 @@ install_restic() {
         exit 1
     fi
 
+    # Remove 'v' prefix from version for comparison and binary download
+    LATEST_VERSION_CLEAN=${LATEST_VERSION#v}
+
     # Check if we need to upgrade
     if [ -n "$INSTALLED_VERSION" ] && [ "$INSTALLED_VERSION" = "$LATEST_VERSION" ]; then
         print_text_in_color "$IGreen" "Latest version $LATEST_VERSION is already installed!"
@@ -90,11 +93,8 @@ install_restic() {
     # Clean up
     rm -rf "$TMP_DIR"
 
-    # Update bash
-    hash -d restic
-
     # Verify installation
-    if ! restic version | grep -q "$LATEST_VERSION"; then
+    if ! restic version | grep -q "$LATEST_VERSION_CLEAN"; then
         msg_box "Failed to verify restic installation."
         exit 1
     fi

--- a/not-supported/restic-cloud-backup-wizard.sh
+++ b/not-supported/restic-cloud-backup-wizard.sh
@@ -4,8 +4,8 @@
 # Sami Nieminen - 2024 https://nenimein.fi
 true
 
-SCRIPT_NAME="Nextcloud Cloud Backup Wizard"
-SCRIPT_EXPLAINER="This script helps creating a backup script for your Nextcloud instance to various cloud storage providers."
+SCRIPT_NAME="Nextcloud Restic cloud backup wizard"
+SCRIPT_EXPLAINER="This script helps creating a backup script for your Nextcloud instance to various cloud storage providers. It uses Restic and backs up your configuration and database."
 
 # shellcheck source=lib.sh
 source /var/scripts/fetch_lib.sh
@@ -235,6 +235,6 @@ msg_box "The backup script has been created successfully!
 Location: $BACKUP_SCRIPT_NAME
 
 The first backup will run automatically at $BACKUP_TIME.
-Please make sure to keep your configuration and passwords safe."
+Please make sure to keep your configuration and API keys safe!"
 
 exit 0

--- a/not-supported/restic-cloud-backup-wizard.sh
+++ b/not-supported/restic-cloud-backup-wizard.sh
@@ -19,9 +19,12 @@ debug_mode
 # Check if root
 root_check
 
+# Get database details
+ncdb
+
 # Variables
 BACKUP_SCRIPT_NAME="$SCRIPTS/restic-cloud-backup.sh"
-BACKUP_CONFIG="$HOME/.restic-cloud_backup_config"
+BACKUP_CONFIG="$HOME/.restic_cloud_backup_config"
 
 # Functions
 choose_backup_location() {
@@ -86,6 +89,7 @@ fi
 # Configure PostgreSQL credentials
 POSTGRES_USER=$NCDBUSER
 POSTGRES_PASSWORD=$NCDBPASS
+POSTGRES_HOST=$NCDBHOST
 
 # Configure backup destination
 choose_backup_location
@@ -115,6 +119,7 @@ fi
 cat > "$BACKUP_CONFIG" << EOL
 POSTGRES_USER="$POSTGRES_USER"
 POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
+POSTGRES_HOST="$POSTGRES_HOST"
 BACKUP_TYPE="$BACKUP_TYPE"
 RESTIC_PASSWORD="$RESTIC_PASSWORD"
 RESTIC_REPOSITORY="$RESTIC_REPOSITORY"
@@ -155,7 +160,7 @@ SCRIPT_EXPLAINER="This script executes the daily backup to cloud storage."
 source /var/scripts/fetch_lib.sh
 
 # Load configuration
-source "$HOME/.restic_backup_config"
+source "$HOME/.restic_cloud_backup_config"
 
 # Export environment variables based on backup type
 case "$BACKUP_TYPE" in
@@ -188,7 +193,7 @@ then
     mkdir -p "$BACKUP_DIR"
 
     # Backup PostgreSQL database
-    PGPASSWORD="$NCDBPASS" pg_dump -U "$POSTGRES_USER" nextcloud > "$BACKUP_DIR/nextcloud_db.sql"
+    PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -U "$POSTGRES_USER" -h "$POSTGRES_HOST" nextcloud > "$BACKUP_DIR/nextcloud_db.sql"
 
     # Backup Nextcloud config
     cp /var/www/nextcloud/config/config.php "$BACKUP_DIR/"

--- a/not-supported/restic-cloud-backup-wizard.sh
+++ b/not-supported/restic-cloud-backup-wizard.sh
@@ -20,8 +20,8 @@ debug_mode
 root_check
 
 # Variables
-BACKUP_SCRIPT_NAME="$SCRIPTS/cloudbackup.sh"
-BACKUP_CONFIG="$HOME/.cloud_backup_config"
+BACKUP_SCRIPT_NAME="$SCRIPTS/restic-cloud-backup.sh"
+BACKUP_CONFIG="$HOME/.restic-cloud_backup_config"
 
 # Functions
 choose_backup_location() {
@@ -33,9 +33,9 @@ choose_backup_location() {
 
     case "$BACKUP_TYPE" in
         "Backblaze B2")
-            B2_ACCOUNT_ID=$(input_box_flow "Enter Backblaze B2 Account ID:")
-            B2_ACCOUNT_KEY=$(input_box_flow "Enter Backblaze B2 Account Key:")
-            B2_BUCKET_NAME=$(input_box_flow "Enter B2 Bucket Name:")
+            B2_ACCOUNT_ID=$(input_box_flow "Enter Backblaze B2 Account ID \nThis is your Application Key keyID:")
+            B2_ACCOUNT_KEY=$(input_box_flow "Enter Backblaze B2 Account Key \nThis is the Application Key Secret:")
+            B2_BUCKET_NAME=$(input_box_flow "Enter Backblaze B2 Bucket Name:")
             RESTIC_REPOSITORY="b2:$B2_BUCKET_NAME:"
             ;;
         "AWS S3")
@@ -58,7 +58,7 @@ choose_backup_location() {
     esac
 
     # Configure restic password
-    RESTIC_PASSWORD=$(input_box_flow "Enter Restic Repository Password:")
+    RESTIC_PASSWORD=$(input_box_flow "Enter Restic Repository Password \nSAVE THIS! \nIF YOU LOSE IT YOU WILL NOT BE ABLE TO RESTORE THIS BACKUP:")
 }
 
 # Ask for execution
@@ -78,7 +78,7 @@ fi
 # Install restic if not installed
 if ! command -v restic &> /dev/null
 then
-    msg_box "Installing restic..."
+    msg_box "Press ok to install Restic"
     apt-get update -q4 & spinner_loading
     apt-get install restic -y
 fi
@@ -235,6 +235,6 @@ msg_box "The backup script has been created successfully!
 Location: $BACKUP_SCRIPT_NAME
 
 The first backup will run automatically at $BACKUP_TIME.
-Please make sure to keep your configuration and API keys safe!"
+Please make sure to keep your configuration, API keys and Restic password safe!"
 
 exit 0

--- a/not-supported/restic-cloud-backup-wizard.sh
+++ b/not-supported/restic-cloud-backup-wizard.sh
@@ -129,7 +129,7 @@ choose_backup_location() {
             AZURE_ACCOUNT_NAME=$(input_box_flow "Enter Azure Storage Account Name")
             AZURE_ACCOUNT_KEY=$(input_box_flow "Enter Azure Storage Account Key:")
             AZURE_CONTAINER_NAME=$(input_box_flow "Enter Azure Storage Account Blob name:")
-            RESTIC_REPOSITORY="azure:${AZURE_ACCOUNT_NAME}:/"
+            RESTIC_REPOSITORY="azure:${AZURE_CONTAINER_NAME}:/"
             ;;
         *)
             msg_box "Invalid selection"
@@ -349,6 +349,7 @@ case "$BACKUP_TYPE" in
     "Azure Blob")
         export AZURE_ACCOUNT_NAME="$AZURE_ACCOUNT_NAME"
         export AZURE_ACCOUNT_KEY="$AZURE_ACCOUNT_KEY"
+        export AZURE_CONTAINER_NAME="$AZURE_CONTAINER_NAME"
         ;;
 esac
 

--- a/not-supported/restic-cloud-backup-wizard.sh
+++ b/not-supported/restic-cloud-backup-wizard.sh
@@ -119,8 +119,8 @@ setup_restic_excludes() {
         echo "# One exclude pattern per line"
         echo ""
 
-        # Add Nextcloud preview excludes if /mnt/ncdata is selected
-        if [ -d "/mnt/ncdata" ] && echo "$BACKUP_DIRECTORIES" | grep -q "/mnt/ncdata"
+        # Add Nextcloud appdata/preview folder excludes if full backup is selected.
+        if [ "$BACKUP_NCDATA" = "yes" ]
         then
             echo ""
             echo "# Nextcloud preview cache"

--- a/not-supported/restic-cloud-backup-wizard.sh
+++ b/not-supported/restic-cloud-backup-wizard.sh
@@ -63,6 +63,7 @@ install_restic() {
     TMP_DIR=$(mktemp -d)
 
     # Download binary
+    print_text_in_color "$ICyan" "Downloading restic $LATEST_VERSION..."
     if ! curl -L "https://github.com/restic/restic/releases/download/$LATEST_VERSION/restic_${LATEST_VERSION#v}_linux_amd64.bz2" -o "$TMP_DIR/restic.bz2"; then
         msg_box "Failed to download restic. Please try again later."
         rm -rf "$TMP_DIR"
@@ -70,6 +71,7 @@ install_restic() {
     fi
 
     # Extract binary
+    print_text_in_color "$ICyan" "Extracting restic binary to $TMP_DIR"
     if ! bunzip2 "$TMP_DIR/restic.bz2"; then
         msg_box "Failed to extract restic binary."
         rm -rf "$TMP_DIR"
@@ -77,6 +79,7 @@ install_restic() {
     fi
 
     # Make executable and move to /usr/local/bin
+    print_text_in_color "$ICyan" "Moving restic binary to /usr/local/bin/"
     chmod +x "$TMP_DIR/restic"
     if ! mv "$TMP_DIR/restic" /usr/local/bin/; then
         msg_box "Failed to install restic binary."
@@ -86,6 +89,9 @@ install_restic() {
 
     # Clean up
     rm -rf "$TMP_DIR"
+
+    # Update bash
+    hash -d restic
 
     # Verify installation
     if ! restic version | grep -q "$LATEST_VERSION"; then


### PR DESCRIPTION
This PR adds options to backup Nextcloud instance to different [Restic](https://restic.readthedocs.io/en/stable/010_introduction.html) supported cloud locations.

Currently script has support for:
- AWS S3 Bucket
- Azure Blob Storage
- Backblaze B2

Tested working with Azure and Backblaze, as I have access to those two environments.

Script has logging, error handling and hopefully clear instuctions how to set it up.
Also has options to only backup the config + DB or config + DB + /mnt/ncdata.

Fixes #2583 