### PR TITLE
Switch Adminer source back to official upstream

### DIFF
--- a/apps/adminer.sh
+++ b/apps/adminer.sh
@@ -52,13 +52,17 @@ a2enmod ssl
 # Install Adminer
 apt-get update -q4 & spinner_loading
 install_if_not adminer
-curl_to_dir "https://download.adminerevo.org/latest/adminer" "adminer-pgsql.zip" "$ADMINERDIR"
-install_if_not unzip
+#re add original repo due to it being maintained again
+curl_to_dir "http://www.adminer.org" "latest.php" "$ADMINERDIR"
+mv "$ADMINERDIR"/latest.php "$ADMINERDIR"/adminer.php
+# curl_to_dir "https://download.adminerevo.org/latest/adminer" "adminer-pgsql.zip" "$ADMINERDIR"
+# install_if_not unzip
 # Unzip the latest version
-unzip "$ADMINERDIR"/adminer-pgsql.zip -d "$ADMINERDIR"
-rm -f "$ADMINERDIR"/adminer-pgsql.zip
+# unzip "$ADMINERDIR"/adminer-pgsql.zip -d "$ADMINERDIR"
+# rm -f "$ADMINERDIR"/adminer-pgsql.zip
 # curl_to_dir "https://raw.githubusercontent.com/Niyko/Hydra-Dark-Theme-for-Adminer/master" "adminer.css" "$ADMINERDIR"
-mv "$ADMINERDIR"/adminer-pgsql.php "$ADMINERDIR"/adminer.php
+# mv "$ADMINERDIR"/adminer-pgsql.php "$ADMINERDIR"/adminer.php
+
 
 # Only add TLS 1.3 on Ubuntu later than 22.04
 if version 22.04 "$DISTRO" 24.04.10


### PR DESCRIPTION
Updated the Adminer installation script to download from the official [adminer.org](https://www.adminer.org/) Source instead of the deprecated adminerevo.org fork. The original upstream project is now maintained again. Commented out the previous download and extraction steps for reference.