### PR TITLE
Comment out curl setting in ddclient config

### DIFF
--- a/network/ddclient-configuration.sh
+++ b/network/ddclient-configuration.sh
@@ -185,7 +185,7 @@ use=web, web=https://api.ipify.org
 # Work around ddclient 3.10.0+ parsing bug by using curl
 # See: https://github.com/ddclient/ddclient/issues/499
 # and: https://github.com/nextcloud/vm/issues/2754
-curl=yes
+# curl=yes
 
 # DDNS-service specific setting
 # Provider=$PROVIDER


### PR DESCRIPTION
Comment out the curl setting to work around ddclient parsing bug.