### PR TITLE
Fix LVM snapshot and disk space logic (closes #1986)

### DIFF
--- a/nextcloud_install_production.sh
+++ b/nextcloud_install_production.sh
@@ -101,7 +101,7 @@ fi
 
 # Create a placeholder volume before modifying anything
 # Ask about snapshots first
-SNAPSHOTS_ENABLED=""
+export SNAPSHOTS_ENABLED=""
 if [ -z "$PROVISIONING" ]
 then
     if ! does_snapshot_exist "NcVM-installation" && yesno_box_no "Do you want to use LVM snapshots to be able to restore your root partition during upgrades and such?
@@ -117,7 +117,7 @@ Enabling this will also force an automatic reboot after running the update scrip
             sleep 1
             # Create a placeholder snapshot
             check_command lvcreate --size 10G --name "NcVM-installation" ubuntu-vg
-            SNAPSHOTS_ENABLED="yes"
+            export SNAPSHOTS_ENABLED="yes"
         else
             print_text_in_color "$IRed" "Could not create volume because of insufficient space..."
             sleep 2
@@ -127,14 +127,14 @@ fi
 
 # Fix LVM on BASE image
 # Ask about disk space - now snapshots have been reserved, we can use remaining space
-USE_ALL_DISK_SPACE=""
+export USE_ALL_DISK_SPACE=""
 if grep -q "LVM" /etc/fstab
 then
     # In provisioning mode, always extend
     # In normal mode, ask the user
     if [ -n "$PROVISIONING" ] || yesno_box_yes "Do you want to make all free space available to your root partition?"
     then
-        USE_ALL_DISK_SPACE="yes"
+        export USE_ALL_DISK_SPACE="yes"
     fi
 fi
 
@@ -166,6 +166,10 @@ then
         fi
     done
 fi
+
+# Cleanup environment variables
+unset SNAPSHOTS_ENABLED
+unset USE_ALL_DISK_SPACE
 
 # Install needed dependencies
 install_if_not lshw


### PR DESCRIPTION
- Ask about snapshots first before disk space question
- Reserve 10G for snapshots, then extend with remaining free space
- This prevents the bug where extending to 100%FREE consumed space needed for snapshots
- Provisioning mode still always extends as before
- Fix whiptail installation to run apt-get update first

@szaimen 