### PR TITLE
Update ddclient configuration for IPv4 usage

### DIFF
--- a/network/ddclient-configuration.sh
+++ b/network/ddclient-configuration.sh
@@ -182,7 +182,7 @@ cat << DDCLIENT_CONF > "/etc/ddclient.conf"
 # /etc/ddclient.conf
 
 # Default system settings
-use=web, web=https://api.ipify.org
+usev4=webv4, webv4=https://api.ipify.org
 
 # Workaround for ddclient 3.10.0+ parsing bug disabled
 # The 'curl=yes' option causes "curl not found" errors even with curl installed


### PR DESCRIPTION
I have some problems with my ddclient updates and consulted the `--help`. It states that the `use=` and `web=` pattern are deprecated in favor of `usev${IPVERSION}` and `webv${IPVERSION}`. Since the `api.ipify.org/` provides me with a IPv4, I assumed the config is for the v4 version.