### PR TITLE
use fork of watchtower to update containers

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -1927,7 +1927,7 @@ fi
 docker_update_specific() {
 if is_docker_running && docker ps -a --format "{{.Names}}" | grep -q "^$1$"
 then
-    if docker run --rm --name temporary_watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --cleanup --run-once "$1"
+    if docker run --rm --name temporary_watchtower -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/nicholas-fedor/watchtower:latest --cleanup --run-once "$1"
     then
         print_text_in_color "$IGreen" "$2 docker image just got updated!"
         echo "Docker image just got updated! We just updated $2 docker image automatically! $(date +%Y%m%d)" >> "$VMLOGS"/update.log


### PR DESCRIPTION
Reason: the containerrr/watchtower image is unfortunately not maintained anymore since 2 years and not compatible with the latest docker releases like v29 anymore which bumped the min api version to v1.44