### PR TITLE
Install php-inotify from the OS package where available

### DIFF
--- a/apps/smbmount.sh
+++ b/apps/smbmount.sh
@@ -341,24 +341,40 @@ We please you to do the math yourself if the number is high enough for your setu
 
             # Install the inotify PHP extension
             # https://github.com/icewind1991/files_inotify/blob/main/README.md
-            if ! pecl list | grep -q inotify
-            then 
-                print_text_in_color "$ICyan" "Installing the PHP inotify extension..."
-                yes no | pecl install inotify
-                local INOTIFY_INSTALL=1
-            fi
             # Get installed php version
             check_php
-            # Enable Inotify
-            if [ ! -f "$PHP_MODS_DIR"/inotify.ini ]
+            if apt-cache show php"$PHPVER"-inotify >/dev/null 2>&1
             then
-                touch "$PHP_MODS_DIR"/inotify.ini
-            fi
-            if ! grep -qFx extension=inotify.so "$PHP_MODS_DIR"/inotify.ini
-            then
-                echo "# PECL inotify" > "$PHP_MODS_DIR"/inotify.ini
-                echo "extension=inotify.so" >> "$PHP_MODS_DIR"/inotify.ini
+                # Available as OS package (Ubuntu 25.10 and later, e.g. php8.5-inotify on 26.04)
+                # https://github.com/nextcloud/vm/issues/2827
+                if ! is_this_installed php"$PHPVER"-inotify
+                then
+                    print_text_in_color "$ICyan" "Installing the PHP inotify extension..."
+                    install_if_not php"$PHPVER"-inotify
+                    local INOTIFY_INSTALL=1
+                fi
                 check_command phpenmod -v ALL inotify
+            else
+                # Not packaged on Ubuntu 24.04 - build it with PECL instead
+                # php-dev is needed for the build (the update script removes it when no PECL packages remain)
+                install_if_not php"$PHPVER"-dev
+                if ! pecl list | grep -q inotify
+                then
+                    print_text_in_color "$ICyan" "Installing the PHP inotify extension..."
+                    yes no | pecl install inotify
+                    local INOTIFY_INSTALL=1
+                fi
+                # Enable Inotify
+                if [ ! -f "$PHP_MODS_DIR"/inotify.ini ]
+                then
+                    touch "$PHP_MODS_DIR"/inotify.ini
+                fi
+                if ! grep -qFx extension=inotify.so "$PHP_MODS_DIR"/inotify.ini
+                then
+                    echo "# PECL inotify" > "$PHP_MODS_DIR"/inotify.ini
+                    echo "extension=inotify.so" >> "$PHP_MODS_DIR"/inotify.ini
+                    check_command phpenmod -v ALL inotify
+                fi
             fi
 
             # Set fs.inotify.max_user_watches to 524288


### PR DESCRIPTION
## Summary

Fixes #2827

The SMB mount script builds the inotify PHP extension with PECL, but since #2780 removed `php-dev` from the base installation, `pecl install inotify` fails on current systems - which is what the reporter of #2827 ran into (their workaround was adding the sury.org repository).

There is no need for a third-party repository:

- **Ubuntu 25.10 and later** ship inotify as an OS package in universe (`php8.5-inotify` on 26.04, which is what the VM currently installs). The script now prefers that when apt knows the package.
- **Ubuntu 24.04** doesn't package it at all (neither does sury.org's Ubuntu PPA change that need - the package simply isn't in noble's archive), so the PECL path is kept as fallback, now with `php-dev` installed first so the build actually succeeds.

## Changes

- `apps/smbmount.sh`: prefer `php$PHPVER-inotify` from apt when available; otherwise install `php$PHPVER-dev` before building via PECL as before.

The OS package ships its own `mods-available/inotify.ini`, so the manual ini handling is only needed on the PECL path. Once 24.04 support is dropped, the PECL path can be removed entirely.
