### PR TITLE
Choose initramfs generator based on Ubuntu release

### DIFF
--- a/not-supported/tpm2-unlock.sh
+++ b/not-supported/tpm2-unlock.sh
@@ -19,6 +19,18 @@ debug_mode
 # Check if root
 root_check
 
+# Noble (24.04) generates the initramfs with initramfs-tools,
+# later releases use dracut
+# https://ubuntu.com/server/docs/how-to/security/tpm-backed-luks-decryption-with-clevis/
+if [ "$CODENAME" = "noble" ]
+then
+    CLEVIS_INITRAMFS_PACKAGE="clevis-initramfs"
+    INITRAMFS_UPDATE=(update-initramfs -u -k 'all')
+else
+    CLEVIS_INITRAMFS_PACKAGE="clevis-dracut"
+    INITRAMFS_UPDATE=(dracut -f)
+fi
+
 # Check if already installed
 if is_this_installed clevis-luks || is_this_installed clevis-tpm2 || is_this_installed clevis-initramfs || is_this_installed clevis-dracut
 then
@@ -71,7 +83,7 @@ then
 fi
 
 # Install needed tools
-apt-get install clevis-tpm2 clevis-luks clevis-initramfs clevis-dracut -y
+apt-get install clevis-tpm2 clevis-luks "$CLEVIS_INITRAMFS_PACKAGE" -y
 
 # Execute the script
 print_text_in_color "$ICyan" "Setting up automatic unlocking via TPM2..."
@@ -79,13 +91,13 @@ if ! echo "$PASSWORD" | clevis luks bind -k - -d "/dev/${ENCRYPTED_DEVICE[*]}" t
 then
     msg_box "Something has failed while trying to configure clevis luks.
 We will now uninstall all needed packets again, so that you are able to start over."
-    apt-get purge clevis-tpm2 clevis-luks clevis-initramfs clevis-dracut -y
+    apt-get purge clevis-tpm2 clevis-luks "$CLEVIS_INITRAMFS_PACKAGE" -y
     apt-get autoremove -y
     msg_box "All installed packets were successfully removed."
     exit 1
 fi
 print_text_in_color "$ICyan" "Updating initramfs..."
-if ! dracut -f
+if ! "${INITRAMFS_UPDATE[@]}"
 then
     msg_box "Errors during initramfs update"
     exit 1


### PR DESCRIPTION
## Problem

#2833 switched `tpm2-unlock.sh` to `dracut -f` unconditionally. That fixed 26.04, but 24.04 is still in the supported range (`SUPPORTED_VERSION_MIN=24.04` in `lib.sh`) and generates its initramfs with initramfs-tools, so the unconditional switch regressed it.

That commit also installed **both** `clevis-initramfs` and `clevis-dracut`. Each ships a hook that injects clevis into the initramfs, so on 26.04 you get the dracut path plus a stale initramfs-tools hook.

## Change

Pick the package and the update command together, once, based on the release codename:

| Release | Package | Command |
| --- | --- | --- |
| noble (24.04) | `clevis-initramfs` | `update-initramfs -u -k 'all'` |
| later (26.04+) | `clevis-dracut` | `dracut -f` |

Three follow-on fixes:

- Only the release-appropriate clevis package is installed, so there are no competing initramfs hooks.
- The rollback `apt-get purge` matches what was installed, so it no longer fails on an absent package.
- The command is held in an array and invoked once, keeping the single `msg_box`/`exit 1` error path rather than duplicating the condition.

The check keys off `$CODENAME` rather than a numeric comparison. `check_distro_version` already rejects anything outside the supported range, and this project only supports LTS releases, so `$DISTRO` can only be 24.04.x or 26.04.x here — a numeric cutoff would have needed a magic version number that appears nowhere in the project's policy. Testing for `noble` also makes dracut the default, so future releases land on the right path automatically.

The `is_this_installed` check still tests both package names on purpose: it's a "have you run this before?" probe, and anyone who ran the script at 58af3bc on 26.04 may have `clevis-initramfs` installed.

## Testing

`shellcheck -x not-supported/tpm2-unlock.sh` passes clean.

I have not verified that `clevis-dracut` exists under exactly that name in the 26.04 archive — that rests on the report in #2833 and the [Ubuntu clevis guide](https://ubuntu.com/server/docs/how-to/security/tpm-backed-luks-decryption-with-clevis/), as it did before this change. Worth a confirmation from someone with a 26.04 box, along with a real 24.04 run to confirm the restored path.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
